### PR TITLE
ci: migrate to GAR from GCR

### DIFF
--- a/.github/workflows/deploy_server_nightly.yml
+++ b/.github/workflows/deploy_server_nightly.yml
@@ -6,7 +6,7 @@ concurrency:
   cancel-in-progress: true
 env:
   IMAGE: reearth/reearth:nightly
-  IMAGE_GCP: us.gcr.io/reearth-oss/reearth:nightly
+  IMAGE_GCP: us-central1-docker.pkg.dev/reearth-oss/reearth/reearth:nightly
   GCP_REGION: us-central1
 jobs:
   deploy_test:
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v0
       - name: Configure docker
-        run: gcloud auth configure-docker --quiet
+        run: gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
       - name: docker push
         run: |
           docker pull $IMAGE


### PR DESCRIPTION
# Overview

Because the GCR (Google Container Registry) will be decommissioned.

* [Transition from Container Registry, Google Cloud](https://cloud.google.com/artifact-registry/docs/transition/transition-from-gcr) 

> Container Registry is deprecated and scheduled for shutdown. After May 15, 2024, Artifact Registry will host images for the gcr.io domain in Google Cloud projects without previous Container Registry usage

## What I've done

Changed the Docker registry to GAR.

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo

* Visualizer version: https://github.com/reearth/reearth-visualizer/pull/1018