### PR TITLE
refactor(web): support for dev plugin urls

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -114,6 +114,7 @@
         "@monaco-editor/react": "4.6.0",
         "@popperjs/core": "2.11.8",
         "@reearth/cesium-mvt-imagery-provider": "1.5.4",
+        "js-yaml": "4.1.0",
         "@reearth/core": "0.0.4",
         "@rot1024/use-transition": "1.0.0",
         "@sentry/browser": "7.77.0",

--- a/web/src/classic/components/molecules/EarthEditor/Header/index.tsx
+++ b/web/src/classic/components/molecules/EarthEditor/Header/index.tsx
@@ -29,16 +29,22 @@ export type Props = {
   currentProject?: Project;
   currentProjectStatus?: Status;
   workspaceId?: string;
+  devPluginExtensions?: { id: string; url: string }[];
   onPublishmentStatusClick?: (p: publishingType) => void;
   onPreviewOpen?: () => void;
+  onDevPluginExtensionsReload?: () => void;
+  onDevPluginsInstall?: () => void;
 } & CommonHeaderProps;
 
 const Header: React.FC<Props> = ({
   currentProject,
   currentProjectStatus,
   workspaceId,
+  devPluginExtensions,
   onPublishmentStatusClick,
   onPreviewOpen,
+  onDevPluginExtensionsReload,
+  onDevPluginsInstall,
   ...props
 }) => {
   const t = useT();
@@ -58,7 +64,23 @@ const Header: React.FC<Props> = ({
 
   const right = (
     <RightArea justify="flex-end" align="center">
-      <PreviewButton
+      {!!devPluginExtensions && (
+        <HeaderButton
+          text={t("Install Dev Plugins")}
+          buttonType="secondary"
+          onClick={onDevPluginsInstall}
+          margin="0 12px 0 0"
+        />
+      )}
+      {!!devPluginExtensions && (
+        <HeaderButton
+          text={t("Reload Dev Plugin Extensions")}
+          buttonType="secondary"
+          onClick={onDevPluginExtensionsReload}
+          margin="0 12px 0 0"
+        />
+      )}
+      <HeaderButton
         text={t("Preview")}
         buttonType="secondary"
         onClick={onPreviewOpen}
@@ -110,7 +132,7 @@ const Header: React.FC<Props> = ({
   return <CommonHeader {...props} center={center} right={right} />;
 };
 
-const PreviewButton = styled(Button)`
+const HeaderButton = styled(Button)`
   white-space: nowrap;
 `;
 

--- a/web/src/classic/components/molecules/Visualizer/Plugin/index.tsx
+++ b/web/src/classic/components/molecules/Visualizer/Plugin/index.tsx
@@ -90,6 +90,7 @@ export default function Plugin({
     modalVisible,
     popupVisible,
     externalRef,
+    renderKey,
     onPreInit,
     onDispose,
     exposed,
@@ -126,6 +127,7 @@ export default function Plugin({
       popupContainer={pluginPopupContainer}
       externalRef={externalRef}
       isMarshalable={isMarshalable}
+      key={renderKey}
       exposed={exposed}
       onError={onError}
       onPreInit={onPreInit}

--- a/web/src/classic/components/organisms/EarthEditor/Header/index.tsx
+++ b/web/src/classic/components/organisms/EarthEditor/Header/index.tsx
@@ -30,6 +30,7 @@ const Header: React.FC<Props> = ({ className }) => {
     validAlias,
     validatingAlias,
     url,
+    devPluginExtensions,
     handlePublicationModalOpen,
     handlePublicationModalClose,
     handleWorkspaceModalOpen,
@@ -42,6 +43,8 @@ const Header: React.FC<Props> = ({ className }) => {
     handleCopyToClipBoard,
     handlePreviewOpen,
     handleLogout,
+    handleDevPluginExtensionsReload,
+    handleDevPluginsInstall,
   } = useHooks();
 
   return (
@@ -55,6 +58,7 @@ const Header: React.FC<Props> = ({ className }) => {
         workspaceId={workspaceId}
         currentWorkspace={currentWorkspace}
         modalShown={workspaceModalVisible}
+        devPluginExtensions={devPluginExtensions}
         onPublishmentStatusClick={handlePublicationModalOpen}
         onSignOut={handleLogout}
         onWorkspaceCreate={handleTeamCreate}
@@ -62,6 +66,8 @@ const Header: React.FC<Props> = ({ className }) => {
         onPreviewOpen={handlePreviewOpen}
         openModal={handleWorkspaceModalOpen}
         onModalClose={handleWorkspaceModalClose}
+        onDevPluginExtensionsReload={handleDevPluginExtensionsReload}
+        onDevPluginsInstall={handleDevPluginsInstall}
       />
       <PublicationModal
         className={className}

--- a/web/src/services/config/index.ts
+++ b/web/src/services/config/index.ts
@@ -47,6 +47,7 @@ export type Config = {
   extensions?: Extensions;
   unsafeBuiltinPlugins?: UnsafeBuiltinPlugin[];
   multiTenant?: Record<string, AuthInfo>;
+  devPluginUrls?: string[];
 } & AuthInfo;
 
 declare global {

--- a/web/src/services/state/index.ts
+++ b/web/src/services/state/index.ts
@@ -144,3 +144,9 @@ const unselectProject = atom(null, (_get, set) => {
   set(sceneMode, "3d");
 });
 export const useUnselectProject = () => useAtom(unselectProject)[1];
+
+const devPluginExtensionRenderKey = atom<number>(0);
+export const useDevPluginExtensionRenderKey = () => useAtom(devPluginExtensionRenderKey);
+
+const devPluginExtensions = atom<{ id: string; url: string }[] | undefined>(undefined);
+export const useDevPluginExtensions = () => useAtom(devPluginExtensions);


### PR DESCRIPTION
# Overview

This PR add a new .env var `REEARTH_WEB_DEV_PLUGIN_URLS` to improve the development experience for plugins.

`REEARTH_WEB_DEV_PLUGIN_URLS`'s value should be an array of urls which serves the plugin files in local.

For example
```
REEARTH_WEB_DEV_PLUGIN_URLS='["http://localhost:5005"]'
```

Plugin developers need to provide plugin files at this url, for example
```
http://localhost:5005/reearth.yml
http://localhost:5005/demo.js
```

With this setup, there'll be two more buttons on Editor's header:
![image](https://github.com/reearth/reearth-classic/assets/21994748/c4ff6b53-a65d-48cf-9073-91d3817d1222)
`Install Dev Plugins` will install the plugins from dev plugin urls.
`Reload Dev Plugin Extensions` will reload the widgets and blocks that been defined in dev plugin yaml file.

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
