### PR TITLE
ci: configure `user.email` for GitHub App

### DIFF
--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -8,9 +8,11 @@ jobs:
     steps:
       - name: git config
         env:
+          GH_APP_ID: ${{ vars.GH_APP_ID }}
           GH_APP_USER: ${{ vars.GH_APP_USER }}
         run: |
           git config --global user.name $GH_APP_USER
+          git config --global user.email $GH_APP_ID+reearth-app[bot]@users.noreply.github.com
           git config --global pull.rebase false
       - uses: actions/create-github-app-token@v1
         id: app-token


### PR DESCRIPTION
# Overview

I added a `user.email` to configure the user email on GitHub Actions.

Because there are some CI errors saying that the `user.email` can't be detected.

Ref: https://github.com/reearth/reearth-classic/actions/runs/9854940554/job/27208812693

> fatal: unable to auto-detect email address (got 'runner@fv-az1456-45.(none)')

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
