### PR TITLE
fix(web): reading viewModel of undefined error on published page

### DIFF
--- a/web/src/classic/components/molecules/Visualizer/Engine/Cesium/core/Imagery.tsx
+++ b/web/src/classic/components/molecules/Visualizer/Engine/Cesium/core/Imagery.tsx
@@ -25,9 +25,14 @@ export type Tile = {
 export type Props = {
   tiles?: Tile[];
   cesiumIonAccessToken?: string;
+  renderKeyByReadonlyProps?: number;
 };
 
-export default function ImageryLayers({ tiles, cesiumIonAccessToken }: Props) {
+export default function ImageryLayers({
+  tiles,
+  cesiumIonAccessToken,
+  renderKeyByReadonlyProps,
+}: Props) {
   const { providers, updated } = useImageryProviders({
     tiles,
     cesiumIonAccessToken,
@@ -40,6 +45,10 @@ export default function ImageryLayers({ tiles, cesiumIonAccessToken }: Props) {
   useLayoutEffect(() => {
     if (updated) setCounter(c => c + 1);
   }, [providers, updated]);
+
+  useLayoutEffect(() => {
+    setCounter(c => c + 1);
+  }, [renderKeyByReadonlyProps]);
 
   return (
     <>

--- a/web/src/classic/components/molecules/Visualizer/Engine/Cesium/core/Indicator.tsx
+++ b/web/src/classic/components/molecules/Visualizer/Engine/Cesium/core/Indicator.tsx
@@ -27,6 +27,7 @@ export default function Indicator({ className, property }: Props): JSX.Element |
   const [img, w, h] = useIcon({ image: indicator_image, imageSize: indicator_image_scale });
 
   useEffect(() => {
+    if (!viewer?.selectionIndicator) return;
     !(!indicator_type || indicator_type === "default")
       ? viewer?.selectionIndicator.viewModel.selectionIndicatorElement.setAttribute(
           "hidden",

--- a/web/src/classic/components/molecules/Visualizer/Engine/Cesium/index.tsx
+++ b/web/src/classic/components/molecules/Visualizer/Engine/Cesium/index.tsx
@@ -57,6 +57,9 @@ const Cesium: React.ForwardRefRenderFunction<EngineRef, EngineProps> = (
     cameraViewBoundariesMaterial,
     mouseEventHandles,
     cesiumIonAccessToken,
+    requestRenderMode,
+    maximumRenderTimeChange,
+    renderKeyByReadonlyProps,
     handleMount,
     handleUnmount,
     handleClick,
@@ -72,6 +75,7 @@ const Cesium: React.ForwardRefRenderFunction<EngineRef, EngineProps> = (
     isLayerDraggable,
     meta,
     ready,
+    shouldRender,
     onLayerSelect,
     onCameraChange,
     onTick,
@@ -104,10 +108,8 @@ const Cesium: React.ForwardRefRenderFunction<EngineRef, EngineProps> = (
         cursor: isLayerDragging ? "grab" : undefined,
         ...style,
       }}
-      requestRenderMode={!property?.timeline?.animation && !isLayerDraggable && !shouldRender}
-      maximumRenderTimeChange={
-        !property?.timeline?.animation && !isLayerDraggable && !shouldRender ? Infinity : undefined
-      }
+      requestRenderMode={requestRenderMode}
+      maximumRenderTimeChange={maximumRenderTimeChange}
       shadows={!!property?.atmosphere?.shadows}
       onClick={handleClick}
       onDoubleClick={mouseEventHandles.doubleclick}
@@ -125,7 +127,11 @@ const Cesium: React.ForwardRefRenderFunction<EngineRef, EngineProps> = (
       onWheel={mouseEventHandles.wheel}>
       <Event onMount={handleMount} onUnmount={handleUnmount} />
       <Clock property={property} onTick={handleTick} />
-      <ImageryLayers tiles={property?.tiles} cesiumIonAccessToken={cesiumIonAccessToken} />
+      <ImageryLayers
+        tiles={property?.tiles}
+        cesiumIonAccessToken={cesiumIonAccessToken}
+        renderKeyByReadonlyProps={renderKeyByReadonlyProps}
+      />
       <Entity>
         <Indicator property={property} />
       </Entity>


### PR DESCRIPTION
# Overview

Once project turns on `animation` on scene settings, this error will occor on published page.

The reason is it triggers an update of `requestRenderMode` and `maximumRenderTimeChange`, leading to `Viewer` reload, and leading to viewer?.selectionIndicator could be undefined sometime.

This is also effecting the update of imagery provider, therefore i added a updater for it.

## What I've done

## What I haven't done

## How I tested

Turn on/off `animation` on scene settings, update the published project and check it.

## Which point I want you to review particularly

## Memo
