### PR TITLE
feat(web): add prop to indicate version in marketplace extension

### DIFF
--- a/web/src/beta/features/ProjectSettings/innerPages/PluginSettings/index.tsx
+++ b/web/src/beta/features/ProjectSettings/innerPages/PluginSettings/index.tsx
@@ -90,6 +90,7 @@ const PluginSettings: React.FC<Props> = ({
                     installedPlugins={marketplacePlugins}
                     onInstall={handleInstallPluginByMarketplace}
                     onUninstall={handleUninstallPlugin}
+                    version={"classic"}
                   />
                 ))}
             </>

--- a/web/src/beta/features/ProjectSettings/innerPages/PluginSettings/index.tsx
+++ b/web/src/beta/features/ProjectSettings/innerPages/PluginSettings/index.tsx
@@ -90,7 +90,7 @@ const PluginSettings: React.FC<Props> = ({
                     installedPlugins={marketplacePlugins}
                     onInstall={handleInstallPluginByMarketplace}
                     onUninstall={handleUninstallPlugin}
-                    version={"classic"}
+                    version={"visualizer"}
                   />
                 ))}
             </>

--- a/web/src/classic/components/molecules/Settings/Project/Plugin/PluginSection/index.tsx
+++ b/web/src/classic/components/molecules/Settings/Project/Plugin/PluginSection/index.tsx
@@ -86,6 +86,7 @@ const PluginSection: React.FC<Props> = ({
                   accessToken={accessToken}
                   onInstall={onInstallFromMarketplace}
                   onUninstall={onUninstall}
+                  version={"classic"}
                 />
               ))}
           </Box>
@@ -102,6 +103,7 @@ const PluginSection: React.FC<Props> = ({
                   accessToken={accessToken}
                   onInstall={onInstallFromMarketplace}
                   onUninstall={onUninstall}
+                  version={"classic"}
                 />
               ))}
           </Box>

--- a/web/src/services/config/extensions.ts
+++ b/web/src/services/config/extensions.ts
@@ -1,3 +1,5 @@
+import { Version } from "@reearth/types";
+
 export type ExtensionType =
   | "dataset-import"
   | "publication"
@@ -14,6 +16,7 @@ export type SharedExtensionProps = {
     text: string,
     heading?: string,
   ) => void;
+  version?: Version;
 };
 
 export type DatasetImportExtensionProps = {

--- a/web/src/services/config/extensions.ts
+++ b/web/src/services/config/extensions.ts
@@ -1,4 +1,4 @@
-import { Version } from "@reearth/types";
+import { VersionForExtension } from "@reearth/types";
 
 export type ExtensionType =
   | "dataset-import"
@@ -16,7 +16,7 @@ export type SharedExtensionProps = {
     text: string,
     heading?: string,
   ) => void;
-  version?: Version;
+  version?: VersionForExtension;
 };
 
 export type DatasetImportExtensionProps = {

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -56,3 +56,5 @@ export type OmitFuncProps3<P extends { [key in string]?: (...args: any) => any }
 };
 
 export type ProjectType = "classic" | "beta";
+
+export type Version = "classic" | "visualizer";

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -57,4 +57,4 @@ export type OmitFuncProps3<P extends { [key in string]?: (...args: any) => any }
 
 export type ProjectType = "classic" | "beta";
 
-export type Version = "classic" | "visualizer";
+export type VersionForExtension = "classic" | "visualizer";


### PR DESCRIPTION
Adding a prop to help conditionally render content in the marketplace extension. Related PR on the marketplace is this https://github.com/reearth/reearth-marketplace/pull/90

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a `version` prop to the `PluginSection` and `PluginSettings` components for improved plugin identification.
	- Introduced new types `Version` and `VersionForExtension` to enhance type definitions across various components.

- **Documentation**
	- Updated type definitions to include the new `version` property in relevant extension types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->