### PR TITLE
fix(web): refactor conditional render on workspace page content and add loading overlay

### DIFF
--- a/web/src/classic/components/organisms/Settings/Workspace/index.tsx
+++ b/web/src/classic/components/organisms/Settings/Workspace/index.tsx
@@ -6,6 +6,7 @@ import DangerSection from "@reearth/classic/components/molecules/Settings/Worksp
 import MembersSection from "@reearth/classic/components/molecules/Settings/Workspace/MembersSection";
 import ProfileSection from "@reearth/classic/components/molecules/Settings/Workspace/ProfileSection";
 import SettingPage from "@reearth/classic/components/organisms/Settings/SettingPage";
+import { Workspace } from "@reearth/services/state";
 
 import useHooks from "./hooks";
 
@@ -47,31 +48,36 @@ const WorkspaceSettings: React.FC<Props> = ({ workspaceId }) => {
     setOwner(o);
   }, [checkOwner]);
 
+  const WorkspaceContent: React.FC<{ currentWorkspace: Workspace; owner: boolean }> = ({
+    currentWorkspace,
+    owner,
+  }) => (
+    <>
+      <ProfileSection
+        currentWorkspace={currentWorkspace}
+        updateWorkspaceName={updateName}
+        owner={owner}
+      />
+      {!currentWorkspace.personal && (
+        <MembersSection
+          me={me}
+          owner={owner}
+          members={members}
+          searchedUser={searchedUser}
+          changeSearchedUser={changeSearchedUser}
+          searchUser={searchUser}
+          addMembersToWorkspace={addMembersToWorkspace}
+          updateMemberOfWorkspace={updateMemberOfWorkspace}
+          removeMemberFromWorkspace={removeMemberFromWorkspace}
+        />
+      )}
+    </>
+  );
+
   return (
     <SettingPage workspaceId={workspaceId} projectId={currentProject?.id}>
       <SettingsHeader currentWorkspace={currentWorkspace} />
-      {currentWorkspace && (
-        <>
-          <ProfileSection
-            currentWorkspace={currentWorkspace}
-            updateWorkspaceName={updateName}
-            owner={owner}
-          />
-          {!currentWorkspace?.personal && (
-            <MembersSection
-              me={me}
-              owner={owner}
-              members={members}
-              searchedUser={searchedUser}
-              changeSearchedUser={changeSearchedUser}
-              searchUser={searchUser}
-              addMembersToWorkspace={addMembersToWorkspace}
-              updateMemberOfWorkspace={updateMemberOfWorkspace}
-              removeMemberFromWorkspace={removeMemberFromWorkspace}
-            />
-          )}
-        </>
-      )}
+      {currentWorkspace && <WorkspaceContent currentWorkspace={currentWorkspace} owner={owner} />}
       {me.myTeam && me.myTeam !== workspaceId && (
         <DangerSection workspace={currentWorkspace} deleteWorkspace={deleteWorkspace} />
       )}

--- a/web/src/classic/components/organisms/Settings/Workspace/index.tsx
+++ b/web/src/classic/components/organisms/Settings/Workspace/index.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useState } from "react";
 
+import Loading from "@reearth/classic/components/atoms/Loading";
 import SettingsHeader from "@reearth/classic/components/molecules/Settings/SettingsHeader";
 import DangerSection from "@reearth/classic/components/molecules/Settings/Workspace/DangerSection";
 import MembersSection from "@reearth/classic/components/molecules/Settings/Workspace/MembersSection";
@@ -25,6 +26,7 @@ const WorkspaceSettings: React.FC<Props> = ({ workspaceId }) => {
     addMembersToWorkspace,
     updateMemberOfWorkspace,
     removeMemberFromWorkspace,
+    loading,
   } = useHooks({ workspaceId });
   const [owner, setOwner] = useState(false);
   const members = currentWorkspace?.members;
@@ -48,27 +50,32 @@ const WorkspaceSettings: React.FC<Props> = ({ workspaceId }) => {
   return (
     <SettingPage workspaceId={workspaceId} projectId={currentProject?.id}>
       <SettingsHeader currentWorkspace={currentWorkspace} />
-      <ProfileSection
-        currentWorkspace={currentWorkspace}
-        updateWorkspaceName={updateName}
-        owner={owner}
-      />
-      {!currentWorkspace?.personal && (
-        <MembersSection
-          me={me}
-          owner={owner}
-          members={members}
-          searchedUser={searchedUser}
-          changeSearchedUser={changeSearchedUser}
-          searchUser={searchUser}
-          addMembersToWorkspace={addMembersToWorkspace}
-          updateMemberOfWorkspace={updateMemberOfWorkspace}
-          removeMemberFromWorkspace={removeMemberFromWorkspace}
-        />
+      {currentWorkspace && (
+        <>
+          <ProfileSection
+            currentWorkspace={currentWorkspace}
+            updateWorkspaceName={updateName}
+            owner={owner}
+          />
+          {!currentWorkspace?.personal && (
+            <MembersSection
+              me={me}
+              owner={owner}
+              members={members}
+              searchedUser={searchedUser}
+              changeSearchedUser={changeSearchedUser}
+              searchUser={searchUser}
+              addMembersToWorkspace={addMembersToWorkspace}
+              updateMemberOfWorkspace={updateMemberOfWorkspace}
+              removeMemberFromWorkspace={removeMemberFromWorkspace}
+            />
+          )}
+        </>
       )}
-      {me.myTeam !== workspaceId && (
+      {me.myTeam && me.myTeam !== workspaceId && (
         <DangerSection workspace={currentWorkspace} deleteWorkspace={deleteWorkspace} />
       )}
+      {loading && <Loading portal overlay />}
     </SettingPage>
   );
 };


### PR DESCRIPTION
# Overview
Refactored the conditional render on the workspace page to only show related content when necessary data has loaded and added a loading overlay used in other pages to indicate the loading state. This was done due to a bug reported that the content on this screen would appear briefly after a page refresh then disappear. The actual cause was the data needed for the page had not yet loaded after a page refresh so it displayed the content without the data briefly. Adding a condition to ensure that the content displays only after the required data had loaded fixed this error.
## What I've done

## What I haven't done

## How I tested
Refreshing the page manually as was reported by QA
## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a loading overlay for improved user experience during data fetching.
	- Updated conditional rendering for profile and members sections based on workspace availability.

- **Bug Fixes**
	- Enhanced rendering logic for the danger section to ensure proper visibility based on team membership.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->