### PR TITLE
fix(web): zoom to 3dtiles layer

### DIFF
--- a/web/src/classic/components/molecules/Visualizer/Engine/Cesium/common.ts
+++ b/web/src/classic/components/molecules/Visualizer/Engine/Cesium/common.ts
@@ -30,6 +30,7 @@ import {
   IntersectionTests,
   Matrix4,
   SceneMode,
+  Cesium3DTileset,
 } from "cesium";
 import { useCallback, MutableRefObject } from "react";
 
@@ -717,4 +718,19 @@ export async function sampleTerrainHeightFromCartesian(scene: Scene, translation
     return;
   }
   return await sampleTerrainHeight(scene, lng, lat);
+}
+
+export function find3dtilesPrimitiveByLayerId(
+  viewer: Viewer,
+  layerId: string,
+): Cesium3DTileset | undefined {
+  if (!layerId) return;
+  const primitives = viewer.scene.primitives;
+  for (let i = 0; i < primitives.length; i++) {
+    const primitive = primitives.get(i);
+    if (primitive instanceof Cesium3DTileset && (primitive as any)[layerIdField] === layerId) {
+      return primitive;
+    }
+  }
+  return;
 }


### PR DESCRIPTION
# Overview

We can't find the entity of 3dtiles by entities.getById api, i added `find3dtilesPrimitiveByLayerId` function to find the zoom target primitive for 3dtiles. 

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new function to enhance the Cesium viewer's capability to locate 3D tiles primitives by layer ID.
	- Improved the `lookAtLayer` method to utilize the new function for more efficient camera zooming to specific tiles.

- **Bug Fixes**
	- Streamlined the logic in the `lookAtLayer` method by removing redundant code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->