### PR TITLE
fix(web): add widget popup menu been cropped

### DIFF
--- a/web/src/classic/components/molecules/EarthEditor/LayerTreeViewItem/LayerActionsList/index.tsx
+++ b/web/src/classic/components/molecules/EarthEditor/LayerTreeViewItem/LayerActionsList/index.tsx
@@ -73,7 +73,10 @@ const LayerActionsList: React.FC<Props> = ({
                 key={i.id}
                 disabled={i.disabled}
                 onClick={() => !i.disabled && onAdd?.(i.id)}>
-                <MenuItemIcon icon={i.icon} size={16} />
+                <IconWrapper>
+                  <MenuItemIcon icon={i.icon} size={16} />
+                </IconWrapper>
+
                 <Text size="xs" customColor>
                   {i.title}
                 </Text>
@@ -125,6 +128,10 @@ const MenuItem = styled(Flex)<{ disabled?: boolean }>`
     background: ${({ disabled, theme }) =>
       !disabled ? theme.classic.selectList.option.hoverBg : undefined};
   }
+`;
+
+const IconWrapper = styled.div`
+  width: ${metricsSizes.s + 16}px;
 `;
 
 const MenuItemIcon = styled(Icon)`


### PR DESCRIPTION
# Overview

A stable width is required for popup adjust its position.

BEFORE
![image](https://github.com/user-attachments/assets/77a95c20-1d0e-4708-8b22-cbb9a242e05f)

AFTER
![image](https://github.com/user-attachments/assets/9902111b-8e51-4587-9bc3-fb4452e86082)


## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
