### PR TITLE
fix: return role property value for member in a workspace

### DIFF
--- a/web/src/classic/components/molecules/Settings/Workspace/MembersSection/index.tsx
+++ b/web/src/classic/components/molecules/Settings/Workspace/MembersSection/index.tsx
@@ -73,10 +73,10 @@ const MembersSection: React.FC<Props> = ({
           )
         }>
         <MemberList>
-          {members.map(({ user, role }) =>
+          {members.map(({ user, role }, index) =>
             user ? (
               <MemberListItem
-                key={user.id}
+                key={index}
                 user={user}
                 role={role}
                 owner={owner}

--- a/web/src/classic/components/molecules/Settings/WorkspaceList/WorkspaceCell/index.tsx
+++ b/web/src/classic/components/molecules/Settings/WorkspaceList/WorkspaceCell/index.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import Avatar from "@reearth/classic/components/atoms/Avatar";
 import Flex from "@reearth/classic/components/atoms/Flex";
 import Text from "@reearth/classic/components/atoms/Text";
+import { Role as RoleUnion } from "@reearth/classic/components/molecules/Settings/Workspace/MemberListItem";
 import { metricsSizes } from "@reearth/classic/theme";
 import { useT } from "@reearth/services/i18n";
 import { styled, useTheme } from "@reearth/services/theme";
@@ -11,7 +12,7 @@ export type Workspace = {
   id: string;
   name: string;
   personal: boolean;
-  members: { userId: string; user?: { name: string } }[];
+  members: { userId: string; role?: RoleUnion; user?: { name: string } }[];
 };
 
 export type Props = {

--- a/web/src/classic/components/organisms/Settings/Workspace/hooks.ts
+++ b/web/src/classic/components/organisms/Settings/Workspace/hooks.ts
@@ -56,6 +56,7 @@ export default (params: Params) => {
             team.members?.map(m => ({
               userId: m.user?.id ?? "",
               user: { name: m.user?.name ?? "" },
+              role: m.role,
             })) ?? [],
         }),
       ) ?? [],

--- a/web/src/classic/components/organisms/Settings/Workspace/hooks.ts
+++ b/web/src/classic/components/organisms/Settings/Workspace/hooks.ts
@@ -24,7 +24,7 @@ type Workspace = {
   id: string;
   name: string;
   personal: boolean;
-  members: { userId: string; role: RoleUnion; user?: { name: string } }[];
+  members: { userId: string; role?: RoleUnion; user?: { name: string } }[];
 };
 
 export default (params: Params) => {

--- a/web/src/classic/components/organisms/Settings/Workspace/hooks.ts
+++ b/web/src/classic/components/organisms/Settings/Workspace/hooks.ts
@@ -24,7 +24,7 @@ type Workspace = {
   id: string;
   name: string;
   personal: boolean;
-  members: { userId: string; user?: { name: string } }[];
+  members: { userId: string; role: RoleUnion; user?: { name: string } }[];
 };
 
 export default (params: Params) => {
@@ -45,6 +45,7 @@ export default (params: Params) => {
 
   const { data, loading, refetch } = useGetTeamsQuery();
   const me = { id: data?.me?.id, myTeam: data?.me?.myTeam?.id };
+
   const workspaces: Workspace[] = useMemo(
     () =>
       data?.me?.teams.map(


### PR DESCRIPTION
# Overview
Added an additional property role to the members array in the workspaces array to improve logic in the workspace settings component `web/src/classic/components/organisms/Settings/Workspace/index.tsx` . There is a check to see if each member has the role of `OWNER` and this determines whether we show the UI to change the workspace name or add a member to a workspace. But it appears that the query to fetch this would only run after a page reload so I refactored the query for this component and seems to have worked. 
## What I've done

## What I haven't done

## How I tested
Navigating to a workspace created by the user should show member related UI. Also tested on Netlify preview url
## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the `MembersSection` component to include member roles in the workspace settings.
  
- **Bug Fixes**
	- Improved the rendering of the member list by adjusting the key prop for better React reconciliation.

- **Documentation**
	- Updated type definitions to reflect the new structure of member data including roles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->