### PR TITLE
fix: add max-height to workspace menu list to enable scroll

### DIFF
--- a/web/src/classic/components/molecules/Common/WorkspaceMenu/index.tsx
+++ b/web/src/classic/components/molecules/Common/WorkspaceMenu/index.tsx
@@ -83,6 +83,8 @@ const WorkspaceMenu: React.FC<Props> = ({
 const DropdownInner = styled.div`
   padding: 0;
   max-width: 230px;
+  max-height: 400px;
+  overflow-y: auto;
 `;
 
 const TeamStatus = styled(Flex)`


### PR DESCRIPTION
# Overview
Set a maximum height to a component only used in the workspace menu to enable scrolling of workspaces if user has many workspaces.

## What I've done

## What I haven't done
Would need to confirm the maximum height value during review I believe 
## How I tested
Tested by generating many workspaces on the frontend and checking that ability to scroll is present
<img width="537" alt="Screenshot 2024-10-30 at 10 28 29 AM" src="https://github.com/user-attachments/assets/fe07470d-4429-4d65-b8bf-672cb969c9ae">


## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the Workspace Menu dropdown with improved scroll behavior for better visibility and accessibility of options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->