### PR TITLE
fix(web): remove`.yarnrc` file mount and disable Corepack

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -7,17 +7,11 @@ ENV NODE_OPTIONS=$NODE_OPTIONS
 ENV GITHUB_SHA=$GITHUB_SHA
 
 RUN --mount=type=bind,source=package.json,target=package.json \
-    --mount=type=cache,target=/root/.npm,sharing=locked \
-    corepack enable
-
-RUN --mount=type=bind,source=.yarnrc.yml,target=.yarnrc.yml \
-    --mount=type=bind,source=package.json,target=package.json \
     --mount=type=bind,source=yarn.lock,target=yarn.lock \
     --mount=type=cache,target=/root/.yarn,sharing=locked \
     yarn install --frozen-lockfile
 
-RUN --mount=type=bind,source=.yarnrc.yml,target=.yarnrc.yml \
-    --mount=type=bind,source=package.json,target=package.json \
+RUN --mount=type=bind,source=package.json,target=package.json \
     --mount=type=bind,source=yarn.lock,target=yarn.lock \
     --mount=type=bind,source=index.html,target=index.html \
     --mount=type=bind,source=published.html,target=published.html \


### PR DESCRIPTION
# Overview

I fixed the Docker build image errors by,

* Removing the `.yarnrc.yaml` which doesn't exist in this project
* Removed `corepack` command which isn't used in this project

## What I've done

Same.

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Streamlined the build process for the Node.js application by simplifying dependency installation.
	- Removed unnecessary commands to enhance efficiency in the Dockerfile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->