### PR TITLE
fix(server): Add padding to widget

### DIFF
--- a/server/pkg/scene/builder/scene.go
+++ b/server/pkg/scene/builder/scene.go
@@ -219,7 +219,7 @@ func buildWidgetArea(a *scene.WidgetArea) *widgetAreaJSON {
 }
 func buildWidgetAreaPadding(p *scene.WidgetAreaPadding) *widgetAreaPaddingJSON {
 	if p == nil {
-		return &widgetAreaPaddingJSON{}
+		return nil
 	}
 	return &widgetAreaPaddingJSON{
 		Top:    p.Top(),

--- a/server/pkg/scene/builder/scene_test.go
+++ b/server/pkg/scene/builder/scene_test.go
@@ -105,14 +105,9 @@ func TestBuildWidgetAlignSystem(t *testing.T) {
 				Inner: &widgetZoneJSON{
 					Left: &widgetSectionJSON{
 						Top: &widgetAreaJSON{
-							WidgetIDs: []string{wid.String()},
-							Align:     "start",
-							Padding: &widgetAreaPaddingJSON{
-								Top:    0,
-								Bottom: 0,
-								Left:   0,
-								Right:  0,
-							},
+							WidgetIDs:  []string{wid.String()},
+							Align:      "start",
+							Padding:    nil,
 							Gap:        nil,
 							Centered:   false,
 							Background: nil,


### PR DESCRIPTION
# Overview

Add padding to widget

## What I've done

I fixed the issue where the widget margins disappear after publishing.
![スクリーンショット 2024-12-02 19 02 42](https://github.com/user-attachments/assets/09911258-329d-410d-9125-7a283761db00)
![スクリーンショット 2024-12-02 19 02 50](https://github.com/user-attachments/assets/0a936167-d7d9-459f-a2e2-a71221a9db83)


## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted handling of widget area padding when no padding information is provided, improving the application's behavior in such scenarios.

- **Tests**
	- Updated expected output for padding in the `TestBuildWidgetAlignSystem` test case to reflect changes in padding representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->