### PR TITLE
fix(web): use `REEARTH_` prefix for frontend runtime envvars

### DIFF
--- a/web/docker/40-envsubst-on-reearth-config.sh
+++ b/web/docker/40-envsubst-on-reearth-config.sh
@@ -24,7 +24,7 @@ _REEARTH_CONFIG_OUTPUT_FILE="/usr/share/nginx/html/reearth_config.json"
 
 # Wrap with "" if the value doesn't start with '{[' and end with ']}' (JSON) or "null".
 wrap_reearth_variables() {
-    for var in $(env | grep '^REEARTH_WEB' | cut -d= -f1); do
+    for var in $(env | grep '^REEARTH_' | cut -d= -f1); do
         value=$(printenv "$var")
         if [ -z "$value" ]; then
             eval "export $var='\"\"'"


### PR DESCRIPTION
# Overview

Currently, the runtime is using the `REEARTH_WEB_` prefix. 
We have decided to use `REEARTH_` instead . 

## What I've done

Migrated to respect runtime environment variables to pick up `REEARTH_` prefixed environment variables.

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded environment variable processing to include all variables starting with `REEARTH_`.
- **Bug Fixes**
	- Ensured variable values are correctly wrapped in quotes based on specified conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->