### PR TITLE
refactor(web): filter out story custom domain extension

### DIFF
--- a/web/src/classic/components/molecules/Settings/Project/PublishSection/hooks.ts
+++ b/web/src/classic/components/molecules/Settings/Project/PublishSection/hooks.ts
@@ -14,12 +14,17 @@ export default (
   publicationStatus?: Status,
   validAlias?: boolean,
   validatingAlias?: boolean,
+  disabledExtensionIds?: string[],
   onAliasValidate?: (alias: string) => void,
   onPublish?: (alias: string | undefined, publicationStatus: Status) => void | Promise<void>,
 ) => {
   const { getAccessToken } = useAuth();
   const url = window.REEARTH_CONFIG?.published?.split("{}");
-  const extensions = window.REEARTH_CONFIG?.extensions?.publication;
+  const extensions = window.REEARTH_CONFIG?.extensions?.publication?.filter(
+    e => !disabledExtensionIds?.includes(e.id),
+  );
+
+  console.log("extensions", extensions);
 
   const [alias, setAlias] = useState(defaultAlias);
   const [validation, setValidation] = useState<Validation>();

--- a/web/src/classic/components/molecules/Settings/Project/PublishSection/hooks.ts
+++ b/web/src/classic/components/molecules/Settings/Project/PublishSection/hooks.ts
@@ -24,8 +24,6 @@ export default (
     e => !disabledExtensionIds?.includes(e.id),
   );
 
-  console.log("extensions", extensions);
-
   const [alias, setAlias] = useState(defaultAlias);
   const [validation, setValidation] = useState<Validation>();
   const [showDModal, setDModal] = useState(false);

--- a/web/src/classic/components/molecules/Settings/Project/PublishSection/index.tsx
+++ b/web/src/classic/components/molecules/Settings/Project/PublishSection/index.tsx
@@ -24,6 +24,7 @@ interface Props {
   validatingAlias?: boolean;
   currentLang?: string;
   currentTheme?: string;
+  disabledExtensionIds?: string[];
   onPublish?: (alias: string | undefined, publicationStatus: Status) => void | Promise<void>;
   onAliasValidate?: (alias: string) => void;
   onNotificationChange?: (type: NotificationType, text: string, heading?: string) => void;
@@ -38,6 +39,7 @@ const PublishSection: React.FC<Props> = ({
   validatingAlias,
   currentLang,
   currentTheme,
+  disabledExtensionIds,
   onPublish,
   onAliasValidate,
   onNotificationChange,
@@ -64,6 +66,7 @@ const PublishSection: React.FC<Props> = ({
     publicationStatus,
     validAlias,
     validatingAlias,
+    disabledExtensionIds,
     onAliasValidate,
     onPublish,
   );

--- a/web/src/classic/components/organisms/Settings/Project/Public/index.tsx
+++ b/web/src/classic/components/organisms/Settings/Project/Public/index.tsx
@@ -12,6 +12,8 @@ import { useT } from "@reearth/services/i18n";
 
 import useHooks from "./hooks";
 
+const DISABLED_EXTENSION_IDS = ["custom-story-domain"];
+
 type Props = {
   projectId: string;
 };
@@ -76,6 +78,7 @@ const Public: React.FC<Props> = ({ projectId }) => {
             validatingAlias={validatingAlias}
             currentLang={currentLang}
             currentTheme={currentTheme}
+            disabledExtensionIds={DISABLED_EXTENSION_IDS}
             onPublish={publishProject}
             onAliasValidate={checkProjectAlias}
             onNotificationChange={handleNotificationChange}


### PR DESCRIPTION
# Overview

Re:Earch Cloud has been updated and added one more extension which is not fit for classic, therefore i filtered it out.

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added ability to disable specific extensions during project publication
	- Introduced configuration to exclude "custom-story-domain" extension

- **Improvements**
	- Enhanced project settings with more granular extension management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->