### PR TITLE
ci: Update GCP auth method from SA key to Workload Identity 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
           fetch-depth: 0
       - name: changed files for web
         id: web
-        uses: tj-actions/changed-files@v36
+        uses: tj-actions/changed-files@v45
         with:
           files: |
-            web
+            web/**
             .github/workflows/ci.yml
             .github/workflows/ci_web.yml
             .github/workflows/build_web.yml
@@ -27,10 +27,10 @@ jobs:
 
       - name: changed files for server
         id: server
-        uses: tj-actions/changed-files@v36
+        uses: tj-actions/changed-files@v45
         with:
           files: |
-            server
+            server/**
             .github/workflows/ci.yml
             .github/workflows/ci_server.yml
             .github/workflows/build_server.yml

--- a/.github/workflows/deploy_server_nightly.yml
+++ b/.github/workflows/deploy_server_nightly.yml
@@ -6,17 +6,21 @@ concurrency:
   cancel-in-progress: true
 env:
   IMAGE: reearth/reearth:nightly
-  IMAGE_GCP: us-central1-docker.pkg.dev/reearth-oss/reearth/reearth:nightly
+  IMAGE_GCP: us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/reearth/reearth:nightly
   GCP_REGION: us-central1
 jobs:
   deploy_test:
     name: Deploy app to test env
     runs-on: ubuntu-latest
     if: github.event.repository.full_name == 'reearth/reearth-classic'
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: google-github-actions/auth@v0
         with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
+          service_account: ${{ secrets.GCP_SA_EMAIL }}
+          workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v0
       - name: Configure docker

--- a/.github/workflows/deploy_web_nightly.yml
+++ b/.github/workflows/deploy_web_nightly.yml
@@ -9,7 +9,7 @@ env:
   GCP_REGION: us-central1
 
   IMAGE: reearth/reearth-classic-web:nightly
-  IMAGE_GCP: us-central1-docker.pkg.dev/reearth-oss/reearth/reearth-classic-web:nightly
+  IMAGE_GCP: us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/reearth/reearth-classic-web:nightly
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true
@@ -19,10 +19,14 @@ jobs:
     name: Deploy test env
     runs-on: ubuntu-latest
     if: github.event.repository.full_name == 'reearth/reearth-classic'
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: google-github-actions/auth@v0
         with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
+          service_account: ${{ secrets.GCP_SA_EMAIL }}
+          workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v0
       - uses: dsaltares/fetch-gh-release-asset@master
@@ -39,10 +43,14 @@ jobs:
     name: Deploy test env
     runs-on: ubuntu-latest
     if: github.event.repository.full_name == 'reearth/reearth-classic'
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: google-github-actions/auth@v0
         with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
+          service_account: ${{ secrets.GCP_SA_EMAIL }}
+          workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v0
       - name: Configure docker


### PR DESCRIPTION
# Overview
- Update auth method from SA key to Workload Identity 
- Bump tj-actions/changed-files from v41 to v45
## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
