### PR TITLE
ci(deploy_web): remove migrated deploy_test_old job

### DIFF
--- a/.github/workflows/deploy_web_nightly.yml
+++ b/.github/workflows/deploy_web_nightly.yml
@@ -2,43 +2,13 @@ name: deploy-web-nightly
 on:
   workflow_dispatch:
 env:
-  # Remove after migrating to Cloud Run
-  REEARTH_URL: test.reearth.dev
-  GCS_DEST: gs://test.reearth.dev/
-
   GCP_REGION: us-central1
-
   IMAGE: reearth/reearth-classic-web:nightly
   IMAGE_GCP: us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/reearth/reearth-classic-web:nightly
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true
 jobs:
-  # Remove after migrating to Cloud Run
-  deploy_test_old:
-    name: Deploy test env
-    runs-on: ubuntu-latest
-    if: github.event.repository.full_name == 'reearth/reearth-classic'
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - uses: google-github-actions/auth@v0
-        with:
-          service_account: ${{ secrets.GCP_SA_EMAIL }}
-          workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0
-      - uses: dsaltares/fetch-gh-release-asset@master
-        with:
-          repo: reearth/reearth-classic
-          version: tags/nightly
-          file: reearth-web_nightly.tar.gz
-          token: ${{ secrets.GITHUB_TOKEN }}
-      - run: tar -xvf reearth-web_nightly.tar.gz
-      - name: rsync
-        run: gsutil -m -h "Cache-Control:no-store" rsync -x "^reearth_config\\.json$|^cesium_ion_token\\.txt$" -dr reearth-web/ $GCS_DEST
-
   deploy_test:
     name: Deploy test env
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Overview
- Since the reearth-classic web migration to cloud run was already completed. There is no use of running job to deploy to GCS anymore

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Streamlined the deployment process by removing the old deployment job and enhancing the existing job for Docker configuration and deployment to Google Cloud Run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->