### PR TITLE
ci(google-github-actions): bump version to v2

### DIFF
--- a/.github/workflows/deploy_server_nightly.yml
+++ b/.github/workflows/deploy_server_nightly.yml
@@ -13,12 +13,12 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: google-github-actions/auth@v0
+      - uses: google-github-actions/auth@v2
         with:
           service_account: ${{ secrets.GC_SA_EMAIL }}
           workload_identity_provider: ${{ secrets.GC_WORKLOAD_IDENTITY_PROVIDER }}
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v2
       - name: Configure docker
         run: gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
       - name: docker push

--- a/.github/workflows/deploy_web_nightly.yml
+++ b/.github/workflows/deploy_web_nightly.yml
@@ -13,12 +13,12 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: google-github-actions/auth@v0
+      - uses: google-github-actions/auth@v2
         with:
           service_account: ${{ secrets.GC_SA_EMAIL }}
           workload_identity_provider: ${{ secrets.GC_WORKLOAD_IDENTITY_PROVIDER }}
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v2
       - name: Configure docker
         run: gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
       - name: docker push


### PR DESCRIPTION
# Overview

- Fix: https://github.com/reearth/reearth-classic/actions/runs/14075284146/job/39417089462

> Run google-github-actions/setup-gcloud@v0
> Error: The v0 series of google-github-actions/setup-gcloud is no longer maintained. It will not receive updates, improvements, or security patches. Please upgrade to the latest supported versions: 
> 
>     https://github.com/google-github-actions/setup-gcloud
> /usr/bin/tar xz --warning=no-unknown-keyword --overwrite -C /home/runner/work/_temp/eae42a28-acc0-4b5f-b875-a[15](https://github.com/reearth/reearth-classic/actions/runs/14075284146/job/39417089462#step:3:16)8d99104e1 -f /home/runner/work/_temp/c28c432b-9865-484e-b248-0886124455b4
> Error: The operation was canceled.

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
