### PR TITLE
feat(web): builtin data attribution widget

### DIFF
--- a/server/pkg/builtin/manifest.yml
+++ b/server/pkg/builtin/manifest.yml
@@ -2286,6 +2286,34 @@ extensions:
                   label: Desktop only
                 - key: mobile
                   label: Mobile only
+  - id: dataattribution
+    type: widget
+    name: Data Attribution
+    description: A data Attribution widget.
+    singleOnly: true
+    widgetLayout:
+      defaultLocation:
+        zone: outer
+        section: left
+        area: bottom
+    schema:
+      groups:
+        - id: default
+          title: Data Attribution
+          list: true
+          representativeField: description
+          fields:
+            - id: description
+              title: Credit Description
+              type: string
+              defaultValue: New Credit
+            - id: logo
+              type: url
+              title: Logo
+              ui: image
+            - id: creditUrl
+              type: url
+              title: Credit Url
   - id: story
     name: Story
     type: story

--- a/server/pkg/builtin/manifest_ja.yml
+++ b/server/pkg/builtin/manifest_ja.yml
@@ -1132,6 +1132,19 @@ extensions:
               always: 常に
               desktop: デスクトップのみ
               mobile: モバイルのみ
+  dataattribution:
+    name: データの帰属
+    description: データ アトリビューション ウィジェット
+    propertySchema:
+      default:
+        title: デフォルト
+        fields:
+          description:
+            title: クレジットの説明
+          logo:
+            title: ロゴ
+          creditUrl:
+            title: クレジット URL
   story:
     name: ストーリー
     description: ストーリーテリングのストーリー

--- a/web/src/classic/components/atoms/Icon/Icons/widgetDataAttribution.svg
+++ b/web/src/classic/components/atoms/Icon/Icons/widgetDataAttribution.svg
@@ -1,0 +1,8 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M6 4H13.5" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M6.00038 8H13.5" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M6.00038 12H13.5" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M2.5 4H3.5" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M2.50038 8H3.5" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M2.50038 12H3.5" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/web/src/classic/components/atoms/Icon/Icons/widgetMenu.svg
+++ b/web/src/classic/components/atoms/Icon/Icons/widgetMenu.svg
@@ -1,2 +1,5 @@
-<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
+  <path d="M2.5 8H13.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M2.5 4H13.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M2.5 12H13.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/web/src/classic/components/atoms/Icon/icons.ts
+++ b/web/src/classic/components/atoms/Icon/icons.ts
@@ -21,6 +21,7 @@ import WidgetButton from "./Icons/widgetButton.svg";
 import WidgetStory from "./Icons/widgetStorytelling.svg";
 import StorytellingMenu from "./Icons/storytellingMenu.svg";
 import WidgetSplash from "./Icons/widgetSplashscreen.svg";
+import WidgetDataAttribution from "./Icons/widgetDataAttribution.svg";
 
 // Workspace
 import Workspaces from "./Icons/workspaces.svg";
@@ -280,6 +281,7 @@ export default {
   timeline: Timeline,
   navigator: WidgetNavigator,
   navigatorAngle: NavigatorAngle,
+  dataattribution: WidgetDataAttribution,
   compass: Compass,
   compassFocus: CompassFocus,
   house: House,

--- a/web/src/classic/components/molecules/Visualizer/Engine/ref.ts
+++ b/web/src/classic/components/molecules/Visualizer/Engine/ref.ts
@@ -83,6 +83,19 @@ export type EngineRef = {
   pluginApi?: any;
   clusterComponent?: ComponentType<ClusterProps>;
   mouseEventCallbacks: MouseEvents;
+  getCredits: () => Credits | undefined;
+};
+
+export type CreditItem = {
+  html?: string;
+};
+
+export type Credits = {
+  engine: {
+    cesium?: CreditItem;
+  };
+  lightbox: CreditItem[];
+  screen: CreditItem[];
 };
 
 export type SceneMode = "3d" | "2d" | "columbus";

--- a/web/src/classic/components/molecules/Visualizer/Widget/DataAttribution/ContentModal.tsx
+++ b/web/src/classic/components/molecules/Visualizer/Widget/DataAttribution/ContentModal.tsx
@@ -1,0 +1,171 @@
+import { FC } from "react";
+import { createPortal } from "react-dom";
+
+import Icon from "@reearth/classic/components/atoms/Icon";
+import { PublishTheme } from "@reearth/classic/theme";
+import { useT } from "@reearth/services/i18n";
+import { styled } from "@reearth/services/theme";
+
+import { VisualizerDOMId } from "../..";
+
+import { ProcessedCredit } from "./useCredits";
+
+type ContentModalProps = {
+  visible?: boolean;
+  credits?: ProcessedCredit[];
+  publishedTheme?: PublishTheme;
+  onClose?: () => void;
+};
+
+const ContentModal: FC<ContentModalProps> = ({ visible, credits, publishedTheme, onClose }) => {
+  const portalRoot = document.getElementById(VisualizerDOMId);
+  const t = useT();
+
+  return visible && portalRoot
+    ? createPortal(
+        <Wrapper>
+          <Panel publishedTheme={publishedTheme}>
+            <Header>
+              <Title>{t("Data Provided by:")}</Title>
+              <CloseButton>
+                <Icon icon="cancel" size={24} onClick={onClose} />
+              </CloseButton>
+            </Header>
+
+            <Content>
+              {credits?.map((credit, index) => (
+                <ListItem key={index}>
+                  <ListMarker>•</ListMarker>
+                  {credit.creditUrl ? (
+                    <CreditItemLink
+                      target="_blank"
+                      href={credit.creditUrl}
+                      rel="noopener noreferrer">
+                      {credit.logo && (
+                        <LogoWrapper>
+                          <StyledImage src={credit.logo} />
+                        </LogoWrapper>
+                      )}
+                      {credit.description && <CreditText>{credit.description}</CreditText>}
+                    </CreditItemLink>
+                  ) : (
+                    <CreditItem>
+                      {credit.logo && (
+                        <LogoWrapper>
+                          <StyledImage src={credit.logo} />
+                        </LogoWrapper>
+                      )}
+                      {credit.description && <CreditText>{credit.description}</CreditText>}
+                    </CreditItem>
+                  )}
+                </ListItem>
+              ))}
+            </Content>
+          </Panel>
+        </Wrapper>,
+        portalRoot,
+      )
+    : null;
+};
+
+const Wrapper = styled("div")(({ theme }) => ({
+  position: "absolute",
+  width: "100%",
+  height: "100%",
+  left: 0,
+  top: 0,
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  backgroundColor: "rgba(0, 0, 0, 0.7)",
+  zIndex: theme.classic.zIndexes.dataAttribution,
+}));
+
+const Panel = styled("div")<{ publishedTheme?: PublishTheme }>(({ theme, publishedTheme }) => ({
+  backgroundColor: publishedTheme?.background || theme.classic.colors.dark.bg[1],
+  color: publishedTheme?.mainText || theme.classic.colors.dark.text.main,
+  fontSize: 12,
+  borderRadius: 8,
+  boxShadow: "0 4px 6px rgba(0, 0, 0, 0.1)",
+  width: "100%",
+  maxWidth: 400,
+  display: "flex",
+  flexDirection: "column",
+  gap: theme.spacing.normal,
+  "& a": {
+    color: publishedTheme?.mainText || theme.classic.colors.dark.text.main,
+  },
+}));
+
+const Header = styled("div")(() => ({
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "space-between",
+  position: "relative",
+  padding: "20px 20px 0 20px",
+}));
+
+const Title = styled("div")(() => ({
+  fontSize: 14,
+  fontWeight: "bold",
+}));
+
+const CloseButton = styled("div")(() => ({
+  cursor: "pointer",
+}));
+
+const Content = styled("div")(() => ({
+  display: "flex",
+  flexDirection: "column",
+  gap: 8,
+  height: "100%",
+  maxHeight: "60vh",
+  overflowY: "auto",
+  padding: "0 20px 20px 20px",
+}));
+
+const ListItem = styled("li")(() => ({
+  display: "flex",
+  alignItems: "center",
+  gap: 12,
+}));
+
+const ListMarker = styled("div")(() => ({
+  width: 5,
+}));
+
+const CreditItem = styled("div")(() => ({
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "flex-start",
+  gap: 8,
+}));
+
+const CreditItemLink = styled("a")(() => ({
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "flex-start",
+  gap: 8,
+}));
+
+const CreditText = styled("span")(() => ({
+  display: "block",
+}));
+
+const LogoWrapper = styled("div")(() => ({
+  position: "relative",
+  boxSizing: "border-box",
+  padding: 4,
+  backgroundColor: "rgba(0, 0, 0, 0.2)",
+  borderRadius: 4,
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+}));
+
+const StyledImage = styled("img")(() => ({
+  maxHeight: 30,
+  width: "auto",
+}));
+
+export default ContentModal;

--- a/web/src/classic/components/molecules/Visualizer/Widget/DataAttribution/ContentModal.tsx
+++ b/web/src/classic/components/molecules/Visualizer/Widget/DataAttribution/ContentModal.tsx
@@ -82,7 +82,7 @@ const Wrapper = styled("div")(({ theme }) => ({
 }));
 
 const Panel = styled("div")<{ publishedTheme?: PublishTheme }>(({ theme, publishedTheme }) => ({
-  backgroundColor: publishedTheme?.background || theme.classic.colors.dark.bg[1],
+  backgroundColor: publishedTheme?.background || theme.classic.main.deepBg,
   color: publishedTheme?.mainText || theme.classic.colors.dark.text.main,
   fontSize: 12,
   borderRadius: 8,

--- a/web/src/classic/components/molecules/Visualizer/Widget/DataAttribution/index.tsx
+++ b/web/src/classic/components/molecules/Visualizer/Widget/DataAttribution/index.tsx
@@ -1,0 +1,90 @@
+import { isEqual } from "lodash-es";
+import { FC, useEffect, useState } from "react";
+
+import { useT } from "@reearth/services/i18n";
+import { styled, usePublishTheme } from "@reearth/services/theme";
+
+import { ComponentProps as WidgetProps } from "..";
+import { Credits } from "../../Engine/ref";
+
+import ContentModal from "./ContentModal";
+import useCredits from "./useCredits";
+
+export type Props = WidgetProps<DataAttributionWidgetProperty>;
+
+export type DataAttributionWidgetProperty = {
+  default?: {
+    id: string;
+    description?: string;
+    logo?: string;
+    creditUrl?: string;
+  }[];
+};
+
+const DataAttribution: FC<Props> = ({ onGetCredits, sceneProperty, widget }) => {
+  const t = useT();
+  const [visible, setVisible] = useState(false);
+  const [credits, setCredits] = useState<Credits>();
+
+  const publishedTheme = usePublishTheme(sceneProperty?.theme);
+
+  useEffect(() => {
+    let intervalId: NodeJS.Timeout | null = null;
+
+    const newCredits = onGetCredits?.();
+    if (newCredits && !isEqual(newCredits, credits)) {
+      setCredits(newCredits);
+    }
+
+    intervalId = setInterval(() => {
+      const newCredits = onGetCredits?.();
+      if (newCredits && !isEqual(newCredits, credits)) {
+        setCredits(newCredits);
+      }
+    }, 3000);
+
+    return () => {
+      if (intervalId) clearInterval(intervalId);
+    };
+  }, [onGetCredits, credits]);
+
+  const { cesiumCredit, otherCredits } = useCredits({ credits, property: widget.property });
+
+  return (
+    <Wrapper>
+      {cesiumCredit && (
+        <CesiumLink target="_blank" href={cesiumCredit.creditUrl} rel="noreferrer">
+          <img src={cesiumCredit.logo} title={cesiumCredit.description} />
+        </CesiumLink>
+      )}
+      <DataLink onClick={() => setVisible(true)}>{t("Data Attribution")}</DataLink>
+      <ContentModal
+        publishedTheme={publishedTheme}
+        visible={visible}
+        credits={otherCredits}
+        onClose={() => setVisible(false)}
+      />
+    </Wrapper>
+  );
+};
+
+const CesiumLink = styled("a")(() => ({
+  height: 28,
+  display: "block",
+  padding: 4,
+}));
+
+const Wrapper = styled("div")(({ theme }) => ({
+  display: "flex",
+  alignItems: "center",
+  gap: theme.spacing.small,
+  fontSize: 12,
+  fontWeight: "bold",
+}));
+
+const DataLink = styled("div")(() => ({
+  cursor: "pointer",
+  padding: 4,
+}));
+
+export default DataAttribution;

--- a/web/src/classic/components/molecules/Visualizer/Widget/DataAttribution/useCredits.ts
+++ b/web/src/classic/components/molecules/Visualizer/Widget/DataAttribution/useCredits.ts
@@ -1,0 +1,68 @@
+import { useEffect, useState } from "react";
+
+import { Credits, CreditItem } from "../../Engine/ref";
+
+import { DataAttributionWidgetProperty } from ".";
+
+type Props = {
+  credits?: Credits;
+  property?: DataAttributionWidgetProperty;
+};
+
+export type ProcessedCredit = {
+  logo?: string;
+  description?: string;
+  creditUrl?: string;
+};
+
+export default ({ credits, property }: Props) => {
+  const [cesiumCredit, setCesiumCredit] = useState<ProcessedCredit | undefined>(undefined);
+  const [otherCredits, setOtherCredits] = useState<ProcessedCredit[] | undefined>(undefined);
+
+  useEffect(() => {
+    if (credits) {
+      const cesium = processCredit(credits.engine?.cesium);
+      setCesiumCredit(cesium);
+
+      const lightboxCredits = credits.lightbox
+        .map(processCredit)
+        .filter(Boolean) as ProcessedCredit[];
+      const screenCredits = credits.screen.map(processCredit).filter(Boolean) as ProcessedCredit[];
+      const widgetCredits =
+        property?.default?.map(credit => ({
+          logo: credit.logo,
+          description: credit.description,
+          creditUrl: credit.creditUrl,
+        })) || [];
+
+      setOtherCredits([...lightboxCredits, ...screenCredits, ...widgetCredits]);
+    }
+  }, [credits, property]);
+
+  return {
+    cesiumCredit,
+    otherCredits,
+  };
+};
+
+function processCredit(credit: CreditItem | undefined): ProcessedCredit | undefined {
+  if (!credit) return undefined;
+
+  if (credit?.html) {
+    try {
+      const parser = new DOMParser();
+      const doc = parser.parseFromString(credit.html, "text/html");
+      const logo = doc.querySelector("img")?.getAttribute("src") || "";
+      const description =
+        doc.querySelector("img")?.getAttribute("title") || doc.body.textContent || "";
+      const creditUrl = doc.querySelector("a")?.getAttribute("href") || "";
+
+      return { logo, description, creditUrl };
+    } catch (error) {
+      console.error("Error processing credit HTML:", error);
+      return undefined;
+    }
+  }
+
+  return undefined;
+}

--- a/web/src/classic/components/molecules/Visualizer/Widget/builtin.ts
+++ b/web/src/classic/components/molecules/Visualizer/Widget/builtin.ts
@@ -1,4 +1,5 @@
 import Button from "./Button";
+import DataAttribution from "./DataAttribution";
 import Menu from "./Menu";
 import Navigator from "./Navigator";
 import SplashScreen from "./SplashScreen";
@@ -13,6 +14,7 @@ export const SPLASHSCREEN_BUILTIN_WIDGET_ID = "reearth/splashscreen";
 export const STORYTELLING_BUILTIN_WIDGET_ID = "reearth/storytelling";
 export const TIMELINE_BUILTIN_WIDGET_ID = "reearth/timeline";
 export const NAVIGATOR_BUILTIN_WIDGET_ID = "reearth/navigator";
+export const DATAATTRIBUTION_BUILTIN_WIDGET_ID = "reearth/dataattribution";
 
 export type BuiltinWidgets<T = unknown> = Record<
   | typeof MENU_BUILTIN_WIDGET_ID
@@ -20,7 +22,8 @@ export type BuiltinWidgets<T = unknown> = Record<
   | typeof SPLASHSCREEN_BUILTIN_WIDGET_ID
   | typeof STORYTELLING_BUILTIN_WIDGET_ID
   | typeof TIMELINE_BUILTIN_WIDGET_ID
-  | typeof NAVIGATOR_BUILTIN_WIDGET_ID,
+  | typeof NAVIGATOR_BUILTIN_WIDGET_ID
+  | typeof DATAATTRIBUTION_BUILTIN_WIDGET_ID,
   T
 >;
 
@@ -31,6 +34,7 @@ const BUILTIN_WIDGET_ID_LIST: BuiltinWidgets<boolean> = {
   [STORYTELLING_BUILTIN_WIDGET_ID]: true,
   [TIMELINE_BUILTIN_WIDGET_ID]: true,
   [NAVIGATOR_BUILTIN_WIDGET_ID]: true,
+  [DATAATTRIBUTION_BUILTIN_WIDGET_ID]: true,
 };
 export const isBuiltinWidget = (id: string): id is keyof BuiltinWidgets =>
   !!BUILTIN_WIDGET_ID_LIST[id as keyof BuiltinWidgets];
@@ -42,6 +46,7 @@ const builtin: BuiltinWidgets<Component> = {
   [STORYTELLING_BUILTIN_WIDGET_ID]: Storytelling,
   [TIMELINE_BUILTIN_WIDGET_ID]: Timeline,
   [NAVIGATOR_BUILTIN_WIDGET_ID]: Navigator,
+  [DATAATTRIBUTION_BUILTIN_WIDGET_ID]: DataAttribution,
 };
 
 export default builtin;

--- a/web/src/classic/components/molecules/Visualizer/Widget/index.tsx
+++ b/web/src/classic/components/molecules/Visualizer/Widget/index.tsx
@@ -1,6 +1,7 @@
 import type * as CSS from "csstype";
 import { ComponentType, useCallback, useMemo } from "react";
 
+import { Credits } from "../Engine/ref";
 import { Viewport } from "../hooks";
 import Plugin, {
   Widget as RawWidget,
@@ -29,6 +30,7 @@ export type Props<PP = any, SP = any> = {
   viewport?: Viewport;
   onExtend?: (id: string, extended: boolean | undefined) => void;
   onVisibilityChange?: (widgetId: string, visible: boolean) => void;
+  onGetCredits: () => Credits | undefined;
 } & PluginCommonProps;
 
 export type ComponentProps<PP = any, SP = any> = Omit<Props<PP, SP>, "widget"> & {

--- a/web/src/classic/components/molecules/Visualizer/WidgetAlignSystem/Area.tsx
+++ b/web/src/classic/components/molecules/Visualizer/WidgetAlignSystem/Area.tsx
@@ -6,6 +6,7 @@ import { useDeepCompareEffect } from "react-use";
 import { WidgetAreaState } from "@reearth/classic/components/organisms/EarthEditor/PropertyPane/hooks";
 import { useTheme } from "@reearth/services/theme";
 
+import { Credits } from "../Engine/ref";
 import { Viewport } from "../hooks";
 import type { CommonProps as PluginCommonProps } from "../Plugin";
 import W, { WidgetLayout } from "../Widget";
@@ -36,6 +37,7 @@ type Props = {
   sceneProperty?: any;
   viewport?: Viewport;
   onWidgetAlignAreaSelect?: (widgetArea?: WidgetAreaState) => void;
+  onGetCredits: () => Credits | undefined;
   // note that layoutConstraint will be always undefined in published pages
   layoutConstraint?: { [w in string]: WidgetLayoutConstraint };
 } & PluginCommonProps;

--- a/web/src/classic/components/molecules/Visualizer/WidgetAlignSystem/MobileZone.tsx
+++ b/web/src/classic/components/molecules/Visualizer/WidgetAlignSystem/MobileZone.tsx
@@ -6,6 +6,7 @@ import Slide from "@reearth/classic/components/atoms/Slide";
 import { WidgetAreaState } from "@reearth/classic/components/organisms/EarthEditor/PropertyPane/hooks";
 import { styled, usePublishTheme, PublishTheme } from "@reearth/services/theme";
 
+import { Credits } from "../Engine/ref";
 import { Viewport } from "../hooks";
 import type { CommonProps as PluginCommonProps } from "../Plugin";
 
@@ -27,6 +28,7 @@ export type Props = {
   viewport?: Viewport;
   invisibleWidgetIDs?: string[];
   onWidgetAlignAreaSelect?: (widgetArea?: WidgetAreaState) => void;
+  onGetCredits: () => Credits | undefined;
 } & PluginCommonProps;
 
 export default function MobileZone({

--- a/web/src/classic/components/molecules/Visualizer/WidgetAlignSystem/Zone.tsx
+++ b/web/src/classic/components/molecules/Visualizer/WidgetAlignSystem/Zone.tsx
@@ -3,6 +3,7 @@ import { GridSection } from "react-align";
 
 import { WidgetAreaState } from "@reearth/classic/components/organisms/EarthEditor/PropertyPane/hooks";
 
+import { Credits } from "../Engine/ref";
 import { Viewport } from "../hooks";
 import type { CommonProps as PluginCommonProps } from "../Plugin";
 
@@ -23,6 +24,7 @@ export type Props = {
   viewport?: Viewport;
   overrideSceneProperty?: (pluginId: string, property: any) => void;
   onWidgetAlignAreaSelect?: (widgetAreaState?: WidgetAreaState) => void;
+  onGetCredits: () => Credits | undefined;
 } & PluginCommonProps;
 
 export default function Zone({

--- a/web/src/classic/components/molecules/Visualizer/WidgetAlignSystem/index.tsx
+++ b/web/src/classic/components/molecules/Visualizer/WidgetAlignSystem/index.tsx
@@ -4,6 +4,7 @@ import { GridWrapper } from "react-align";
 import { WidgetAreaState } from "@reearth/classic/components/organisms/EarthEditor/PropertyPane/hooks";
 import { styled } from "@reearth/services/theme";
 
+import { Credits } from "../Engine/ref";
 import { Viewport } from "../hooks";
 import type { CommonProps as PluginCommonProps } from "../Plugin";
 
@@ -52,6 +53,7 @@ export type Props = {
   overrideSceneProperty?: (pluginId: string, property: any) => void;
   onWidgetAlignAreaSelect?: (widgetArea?: WidgetAreaState) => void;
   onVisibilityChange?: (widgetId: string, visible: boolean) => void;
+  onGetCredits: () => Credits | undefined;
 } & PluginCommonProps;
 
 const WidgetAlignSystem: React.FC<Props> = ({

--- a/web/src/classic/components/molecules/Visualizer/hooks.ts
+++ b/web/src/classic/components/molecules/Visualizer/hooks.ts
@@ -294,6 +294,10 @@ export default ({
   const [shownPluginPopupInfo, onPluginPopupShow] = useState<PluginPopupInfo>();
   const pluginPopupContainerRef = useRef<HTMLDivElement>();
 
+  const getCredits = useCallback(() => {
+    return engineRef.current?.getCredits();
+  }, [engineRef]);
+
   return {
     engineRef,
     wrapperRef,
@@ -329,6 +333,7 @@ export default ({
     handleLayerDrag,
     handleLayerDrop,
     handleInfoboxMaskClick,
+    getCredits,
   };
 };
 

--- a/web/src/classic/components/molecules/Visualizer/index.tsx
+++ b/web/src/classic/components/molecules/Visualizer/index.tsx
@@ -78,6 +78,8 @@ export type Props = {
     "onBlockChange" | "onBlockDelete" | "onBlockMove" | "onBlockInsert" | "onBlockSelect"
   >;
 
+export const VisualizerDOMId = "reearth-classic-visualizer";
+
 export default function Visualizer({
   ready,
   rootLayerId,
@@ -146,6 +148,7 @@ export default function Visualizer({
     handleLayerDrag,
     handleLayerDrop,
     handleInfoboxMaskClick,
+    getCredits,
   } = useHooks({
     engineType: props.engine,
     rootLayerId,
@@ -175,7 +178,7 @@ export default function Visualizer({
   return (
     <ErrorBoundary FallbackComponent={Err}>
       <Provider {...providerProps}>
-        <Filled ref={wrapperRef}>
+        <Filled ref={wrapperRef} id={VisualizerDOMId} className={props.className}>
           {isDroppable && <DropHolder />}
           {ready && widgets?.alignSystem && (
             <WidgetAlignSystem
@@ -200,6 +203,7 @@ export default function Visualizer({
               onWidgetAlignAreaSelect={onWidgetAlignAreaSelect}
               invisibleWidgetIDs={invisibleWidgetIDs}
               onVisibilityChange={onPluginWidgetVisibilityChange}
+              onGetCredits={getCredits}
             />
           )}
           <Engine
@@ -256,6 +260,7 @@ export default function Visualizer({
                   inEditor={inEditor}
                   pluginBaseUrl={pluginBaseUrl}
                   viewport={viewport}
+                  onGetCredits={getCredits}
                 />
               ))}
           </Engine>

--- a/web/src/classic/components/organisms/EarthEditor/core/CanvasArea/hooks.ts
+++ b/web/src/classic/components/organisms/EarthEditor/core/CanvasArea/hooks.ts
@@ -1,5 +1,14 @@
 import { useMemo, useEffect, useCallback } from "react";
 
+import {
+  Widget,
+  WidgetAlignSystem,
+  WidgetLayoutConstraint,
+} from "@reearth/classic/components/molecules/Visualizer";
+import {
+  BuiltinWidgets,
+  DATAATTRIBUTION_BUILTIN_WIDGET_ID,
+} from "@reearth/classic/components/molecules/Visualizer/Widget/builtin";
 import type { Alignment, Location } from "@reearth/classic/core/Crust";
 import {
   convertLegacyLayer,
@@ -150,7 +159,28 @@ export default (isBuilt?: boolean) => {
     return l ? [l] : undefined;
   }, [datasetLoaded, datasets, layerData?.node]);
 
-  const widgets = useMemo(() => convertWidgets(sceneData), [sceneData]);
+  const widgets = useMemo(() => {
+    const commonWidgets = convertWidgets(sceneData);
+
+    if (commonWidgets?.ownBuiltinWidgets) {
+      commonWidgets.ownBuiltinWidgets = commonWidgets.ownBuiltinWidgets.filter(
+        w => w !== "reearth/dataattribution",
+      );
+    }
+
+    return commonWidgets as
+      | {
+          floatingWidgets: Widget[];
+          alignSystem: WidgetAlignSystem;
+          layoutConstraint: { [w in string]: WidgetLayoutConstraint } | undefined;
+          ownBuiltinWidgets: Exclude<
+            keyof BuiltinWidgets,
+            typeof DATAATTRIBUTION_BUILTIN_WIDGET_ID
+          >[];
+        }
+      | undefined;
+  }, [sceneData]);
+
   const sceneProperty = useMemo(() => processProperty(scene?.property), [scene?.property]);
   const tags = useMemo(() => processSceneTags(scene?.tags ?? []), [scene?.tags]);
 

--- a/web/src/classic/theme/reearthTheme/common/zIndex.ts
+++ b/web/src/classic/theme/reearthTheme/common/zIndex.ts
@@ -12,6 +12,7 @@ const zIndex = {
   loading: 800,
   notificationBar: 1000,
   splashScreen: 700,
+  dataAttribution: 450,
   settingHeader: 300,
   menuForDevice: 200,
 };

--- a/web/src/services/i18n/translations/en.yml
+++ b/web/src/services/i18n/translations/en.yml
@@ -522,6 +522,8 @@ This is your personal workspace. Your projects and resources will be managed in 
 All workspaces: All workspaces
 Double click here to write.: Double click here to write.
 Move mouse here and click "+" to add content: Move mouse here and click "+" to add content
+'Data Provided by:': ''
+Data Attribution: ''
 Your account has been successfully verified! Feel free to login now.: Your account has been successfully verified! Feel free to login now.
 Could not verify your signup. Please start the process over.: Could not verify your signup. Please start the process over.
 Failed to add one or more assets.: Failed to add one or more assets.

--- a/web/src/services/i18n/translations/ja.yml
+++ b/web/src/services/i18n/translations/ja.yml
@@ -479,6 +479,8 @@ This is your personal workspace. Your projects and resources will be managed in 
 All workspaces: すべてのワークスペース
 Double click here to write.: ダブルクリックで入力
 Move mouse here and click "+" to add content: マウスをここへ、“+”をクリックしコンテンツを追加
+'Data Provided by:': 'データ提供元：'
+Data Attribution: 'データ帰属'
 Your account has been successfully verified! Feel free to login now.: メールアドレスが認証されました。ログインが可能です。
 Could not verify your signup. Please start the process over.: メールアドレスが認証できませんでした。もう一度最初からやり直してください。
 Failed to add one or more assets.: アセットの作成に失敗しました。


### PR DESCRIPTION
# Overview

This PR added builtin data attribution widget.

## What I've done

- Implement getCredits on engineRef
- Add builtin widget, id as `dataattribution` (naming format reference other classic builtin widgets' naming)
- Update menifest on server

## What I haven't done

- Ignored the case that core enabled.
- Didn't implement the logic that auto add this widget when create a new project.

## How I tested

## Which point I want you to review particularly

## Memo
