### PR TITLE
feat(server): default sorting projects [VIZ-1729]

### DIFF
--- a/server/internal/infrastructure/mongo/project.go
+++ b/server/internal/infrastructure/mongo/project.go
@@ -161,7 +161,11 @@ func (r *Project) findOne(ctx context.Context, filter any, filterByWorkspaces bo
 
 func (r *Project) paginate(ctx context.Context, filter bson.M, pagination *usecasex.Pagination) ([]*project.Project, *usecasex.PageInfo, error) {
 	c := mongodoc.NewProjectConsumer(r.f.Readable)
-	pageInfo, err := r.client.Paginate(ctx, filter, nil, pagination, c)
+	sort := &usecasex.Sort{
+		Key:      "UPDATEDAT",
+		Reverted: true, //  "DESC"
+	}
+	pageInfo, err := r.client.Paginate(ctx, filter, sort, pagination, c)
 	if err != nil {
 		return nil, nil, rerror.ErrInternalByWithContext(ctx, err)
 	}


### PR DESCRIPTION
# Overview

## Default Project Sorting Settings

* In the latest version of Re:EarthX, it is necessary to specify the sort option for projects.
* If no sort option is specified, projects will be naturally sorted in the order they were inserted into MongoDB.
* Since project does not have a createdAt field, sorting is configured in descending order using the updatedAt field.

## What I've done
![スクリーンショット 2025-06-03 18 41 37](https://github.com/user-attachments/assets/f2cc7bdf-3bb5-4bf0-a070-8a7096d20f31)

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
