### PR TITLE
fix(server): set publicNoIndex correctly when publishing projects

### DIFF
--- a/server/internal/usecase/interactor/project.go
+++ b/server/internal/usecase/interactor/project.go
@@ -420,6 +420,18 @@ func (i *Project) Publish(ctx context.Context, params interfaces.PublishProjectP
 	prj.UpdatePublishmentStatus(params.Status)
 	prj.SetPublishedAt(time.Now())
 
+	// Update publicNoIndex based on publishing status
+	switch params.Status {
+	case project.PublishmentStatusLimited:
+		// "limited" status means the project should not be indexed by search engines
+		prj.UpdatePublicNoIndex(true)
+	case project.PublishmentStatusPublic:
+		// "public" status means the project can be indexed by search engines
+		prj.UpdatePublicNoIndex(false)
+	case project.PublishmentStatusPrivate:
+		// For "private" status, we don't need to set publicNoIndex since the project won't be accessible anyway
+	}
+
 	if err := i.projectRepo.Save(ctx, prj); err != nil {
 		return nil, err
 	}

--- a/server/internal/usecase/interactor/project.go
+++ b/server/internal/usecase/interactor/project.go
@@ -420,16 +420,12 @@ func (i *Project) Publish(ctx context.Context, params interfaces.PublishProjectP
 	prj.UpdatePublishmentStatus(params.Status)
 	prj.SetPublishedAt(time.Now())
 
-	// Update publicNoIndex based on publishing status
 	switch params.Status {
 	case project.PublishmentStatusLimited:
-		// "limited" status means the project should not be indexed by search engines
 		prj.UpdatePublicNoIndex(true)
 	case project.PublishmentStatusPublic:
-		// "public" status means the project can be indexed by search engines
 		prj.UpdatePublicNoIndex(false)
 	case project.PublishmentStatusPrivate:
-		// For "private" status, we don't need to set publicNoIndex since the project won't be accessible anyway
 	}
 
 	if err := i.projectRepo.Save(ctx, prj); err != nil {


### PR DESCRIPTION
# Overview
Set publicNoIndex correctly when publishing projects

## What I've done
When publishing a project with "Search engine indexing" disabled (status="limited"),
the publicNoIndex field was not being set to true, causing the noindex meta tag
to not be rendered. This allowed search engines to index projects that should
have been excluded from search results.

This fix ensures that:
- Projects published with status="limited" have publicNoIndex=true
- Projects published with status="public" have publicNoIndex=false
- The noindex meta tag is properly rendered for limited visibility projects

Fixes the issue where projects with disabled search indexing still appear
in search engine results.

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
