### PR TITLE
fix(server): Workspace fetch issue

### DIFF
--- a/server/internal/app/usecase.go
+++ b/server/internal/app/usecase.go
@@ -30,8 +30,14 @@ func UsecaseMiddleware(r *repo.Container, g *gateway.Container, ar *accountrepo.
 
 		var ar2 *accountrepo.Container
 		if op := adapter.AcOperator(ctx); op != nil && ar != nil {
-			// apply filters to repos
-			ar2 = ar.Filtered(accountrepo.WorkspaceFilterFromOperator(op))
+			// Only apply filtering if operator has workspaces
+			// This prevents circular dependency during initial workspace fetch (GetMe query)
+			// where the operator needs workspaces but can't get them because the filter blocks them
+			if len(op.AllReadableWorkspaces()) > 0 {
+				ar2 = ar.Filtered(accountrepo.WorkspaceFilterFromOperator(op))
+			} else {
+				ar2 = ar
+			}
 		} else {
 			ar2 = ar
 		}


### PR DESCRIPTION
# Overview

## The user workspace can be created, but it cannot be retrieved.

## What I've done

In the GCP environment, new users or Operators start from an empty state.
Therefore, when the Operator’s workspace list is empty (at first login) and filtering is applied, a circular reference occurs.
Note: This issue does not occur in the local environment.

To address this, we will make the following changes:

1. At first login (when AllReadableWorkspaces() is empty):
* Skip filtering
* Successfully retrieve workspaces via GetMe
* Update the Operator’s workspace list

2. From the second request onward (when AllReadableWorkspaces() has values):
* Apply filtering as usual
* Security is preserved

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
