### PR TITLE
fix(server): switch db bug fix

### DIFF
--- a/server/internal/infrastructure/mongo/container.go
+++ b/server/internal/infrastructure/mongo/container.go
@@ -25,7 +25,7 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
-func New(ctx context.Context, db *mongo.Database, accountContainer_With_ReearthAccountDbClient *accountrepo.Container, useTransaction bool) (*repo.Container, error) {
+func New(ctx context.Context, db *mongo.Database, accountContainerWithReearthAccountDbClient *accountrepo.Container, useTransaction bool) (*repo.Container, error) {
 	lock, err := NewLock(db.Collection("locks"))
 	if err != nil {
 		return nil, err
@@ -58,8 +58,8 @@ func New(ctx context.Context, db *mongo.Database, accountContainer_With_ReearthA
 		Storytelling:   NewStorytelling(reearthDbClient),
 		Lock:           lock,
 		Transaction:    reearthDbClient.Transaction(),
-		Workspace:      accountContainer_With_ReearthAccountDbClient.Workspace,
-		User:           accountContainer_With_ReearthAccountDbClient.User,
+		Workspace:      accountContainerWithReearthAccountDbClient.Workspace,
+		User:           accountContainerWithReearthAccountDbClient.User,
 	}
 
 	// init


### PR DESCRIPTION
# Overview

## Both refer to the same database.
## The database switch is not working properly.

## What I've done
In the New function of server/internal/infrastructure/mongo/container.go, even though the parameter account *accountrepo.Container is passed in, lines 61–62 were using the wrong database client:
```
Workspace: NewWorkspaceWrapper(client),
User:      NewUserWrapper(client),
```
This client is for the "reearth" database, but Workspace and User are stored in the "reearth-account" database.

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
