### PR TITLE
fix(ci): add contents:write permission to release jobs

### DIFF
--- a/.github/workflows/build_server.yml
+++ b/.github/workflows/build_server.yml
@@ -23,6 +23,8 @@ jobs:
   build-server:
     name: Build and release server
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     if: github.event.inputs.name || github.event.inputs.new_tag
     env:
       ARTIFACTS: server/dist/reearth_*.*

--- a/.github/workflows/build_web.yml
+++ b/.github/workflows/build_web.yml
@@ -65,6 +65,8 @@ jobs:
     name: Release nightly/rc
     runs-on: ubuntu-latest
     needs: [build-web]
+    permissions:
+      contents: write
     if: ${{ github.event.inputs.name != 'blank' }}
     env:
       ARTIFACT: reearth-web_${{ github.event.inputs.name }}.tar.gz
@@ -238,6 +240,8 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     if: ${{ github.event.inputs.new_tag != 'blank' }}
     env:
       ARTIFACT: reearth-web_${{ github.event.inputs.new_tag }}.tar.gz


### PR DESCRIPTION
ncipollo/release-action requires contents:write to create/update GitHub releases. Adds the permission to the affected jobs in build_web.yml and build_server.yml to resolve the 403 error.

