### PR TITLE
chore: limit renovate auto-rebase to conflicted branches only

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,5 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>reearth/renovate-config"
-  ]
+  ],
+  "rebaseWhen": "conflicted"
 }


### PR DESCRIPTION
## Problem

Every push to `main` triggers Renovate to rebase all open PRs, even when there are no merge conflicts. With many open Renovate PRs, this creates a cascade:

- Each merge to `main` causes Renovate to rebase all its open PRs simultaneously
- Each rebase fires a `pull_request: synchronize` event, triggering a full CI run per PR
- This wastes CI minutes on PRs that were already passing with no relevant changes

## Fix

Set `rebaseWhen: "conflicted"` in `.github/renovate.json`. Renovate will now only rebase a PR when it has an actual merge conflict — not just because it's behind `main`.

This overrides the default `"auto"` behaviour from the shared `github>reearth/renovate-config` without touching that shared config.

Mirrors the same change made in reearth-visualizer: reearth/reearth-visualizer#2200