### PR TITLE
fix(web): remove problematic mapping

### DIFF
--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -27,17 +27,7 @@
       ],
       "@reearth/*": [
         "src/*"
-      ],
-      "react-align": [
-        "node_modules/react-align/dist/index.d.ts"
-      ],
-      "cesium-dnd": [
-        "node_modules/cesium-dnd/dist/index.d.ts"
-      ],
-      "cesium-mvt-imagery-provider": [
-        "node_modules/cesium-mvt-imagery-provider/dist/index.d.ts"
-      ],
-      "quickjs-emscripten-sync": ["node_modules/quickjs-emscripten-sync/dist/index.d.ts"]
+      ]
     },
     "plugins": [
       {


### PR DESCRIPTION
# Overview

1. Both TypeScript AND Vite use the path mapping
2. Vite tries to load .d.ts at runtime ❌
3. Browser fails because .d.ts has no executable code ❌

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
