### PR TITLE
fix(server): migrate stamen_toner to open_street_map instead of carto_light

### DIFF
--- a/server/internal/infrastructure/mongo/migration/260525000715_revert_tile_and_terrain_providers.go
+++ b/server/internal/infrastructure/mongo/migration/260525000715_revert_tile_and_terrain_providers.go
@@ -19,7 +19,7 @@ import (
 // - "cesium_ion" with asset_id 3 → "default_label" (and remove asset_id field)
 // - "cesium_ion" with asset_id 4 → "default_road" (and remove asset_id field)
 // - "cesium_ion" with asset_id 3812 → "black_marble" (and remove asset_id field)
-// - "open_street_map" → "esri_world_topo" (best-effort: also covers stamen_toner → open_street_map)
+// - "open_street_map" → "esri_world_topo"
 // Terrain reversion rules:
 // - "reearth_terrain" → "arcgis"
 func RevertTileAndTerrainProviders(ctx context.Context, c DBClient) error {
@@ -47,8 +47,6 @@ func RevertTileAndTerrainProviders(ctx context.Context, c DBClient) error {
 	}
 
 	// Reversion 5: open_street_map → esri_world_topo (simple rename)
-	// Note: stamen_toner also maps to open_street_map in the forward migration,
-	// so this revert is best-effort — stamen_toner tiles will be reverted to esri_world_topo.
 	if err := revertTileSimpleRename(ctx, col, "open_street_map", "esri_world_topo"); err != nil {
 		return fmt.Errorf("failed to revert tile 'open_street_map': %w", err)
 	}

--- a/server/internal/infrastructure/mongo/migration/260525000715_revert_tile_and_terrain_providers.go
+++ b/server/internal/infrastructure/mongo/migration/260525000715_revert_tile_and_terrain_providers.go
@@ -19,8 +19,7 @@ import (
 // - "cesium_ion" with asset_id 3 → "default_label" (and remove asset_id field)
 // - "cesium_ion" with asset_id 4 → "default_road" (and remove asset_id field)
 // - "cesium_ion" with asset_id 3812 → "black_marble" (and remove asset_id field)
-// - "carto_light" → "stamen_toner"
-// - "open_street_map" → "esri_world_topo"
+// - "open_street_map" → "esri_world_topo" (best-effort: also covers stamen_toner → open_street_map)
 // Terrain reversion rules:
 // - "reearth_terrain" → "arcgis"
 func RevertTileAndTerrainProviders(ctx context.Context, c DBClient) error {
@@ -47,12 +46,9 @@ func RevertTileAndTerrainProviders(ctx context.Context, c DBClient) error {
 		return fmt.Errorf("failed to revert cesium_ion (asset_id: 3812) to 'black_marble': %w", err)
 	}
 
-	// Reversion 5: carto_light → stamen_toner (simple rename)
-	if err := revertTileSimpleRename(ctx, col, "carto_light", "stamen_toner"); err != nil {
-		return fmt.Errorf("failed to revert tile 'carto_light': %w", err)
-	}
-
-	// Reversion 6: open_street_map → esri_world_topo (simple rename)
+	// Reversion 5: open_street_map → esri_world_topo (simple rename)
+	// Note: stamen_toner also maps to open_street_map in the forward migration,
+	// so this revert is best-effort — stamen_toner tiles will be reverted to esri_world_topo.
 	if err := revertTileSimpleRename(ctx, col, "open_street_map", "esri_world_topo"); err != nil {
 		return fmt.Errorf("failed to revert tile 'open_street_map': %w", err)
 	}

--- a/server/internal/infrastructure/mongo/migration/260525000715_revert_tile_and_terrain_providers_test.go
+++ b/server/internal/infrastructure/mongo/migration/260525000715_revert_tile_and_terrain_providers_test.go
@@ -204,19 +204,12 @@ func TestRevertTileAndTerrainProviders_TileReversions(t *testing.T) {
 
 	// Verify doc6: cesium_ion with asset_id 999 unchanged
 	var updatedDoc6 bson.M
-	err = db.Collection("property").FindOne(ctx, bson.M{"_id": doc5["_id"]}).Decode(&updatedDoc6)
+	err = db.Collection("property").FindOne(ctx, bson.M{"_id": doc6["_id"]}).Decode(&updatedDoc6)
 	require.NoError(t, err)
-	value6 := updatedDoc6["items"].(primitive.A)[0].(bson.M)["groups"].(primitive.A)[0].(bson.M)["fields"].(primitive.A)[0].(bson.M)["value"]
-	assert.Equal(t, "esri_world_topo", value6)
-
-	
-	var updatedDoc7 bson.M
-	err = db.Collection("property").FindOne(ctx, bson.M{"_id": doc6["_id"]}).Decode(&updatedDoc7)
-	require.NoError(t, err)
-	fields7 := updatedDoc7["items"].(primitive.A)[0].(bson.M)["groups"].(primitive.A)[0].(bson.M)["fields"].(primitive.A)
-	assert.Len(t, fields7, 2)
-	assert.Equal(t, "cesium_ion", fields7[0].(bson.M)["value"])
-	assert.Equal(t, float64(999), fields7[1].(bson.M)["value"])
+	fields6 := updatedDoc6["items"].(primitive.A)[0].(bson.M)["groups"].(primitive.A)[0].(bson.M)["fields"].(primitive.A)
+	assert.Len(t, fields6, 2)
+	assert.Equal(t, "cesium_ion", fields6[0].(bson.M)["value"])
+	assert.Equal(t, float64(999), fields6[1].(bson.M)["value"])
 }
 
 func TestRevertTileAndTerrainProviders_TerrainReversions(t *testing.T) {

--- a/server/internal/infrastructure/mongo/migration/260525000715_revert_tile_and_terrain_providers_test.go
+++ b/server/internal/infrastructure/mongo/migration/260525000715_revert_tile_and_terrain_providers_test.go
@@ -109,27 +109,8 @@ func TestRevertTileAndTerrainProviders_TileReversions(t *testing.T) {
 		},
 	}
 
-	// Test case 5: carto_light → stamen_toner
+	// Test case 5: open_street_map → esri_world_topo
 	doc5 := bson.M{
-		"_id": primitive.NewObjectID(),
-		"items": bson.A{
-			bson.M{
-				"groups": bson.A{
-					bson.M{
-						"fields": bson.A{
-							bson.M{
-								"field": "tile_type",
-								"value": "carto_light",
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	// Test case 6: open_street_map → esri_world_topo
-	doc6 := bson.M{
 		"_id": primitive.NewObjectID(),
 		"items": bson.A{
 			bson.M{
@@ -148,7 +129,7 @@ func TestRevertTileAndTerrainProviders_TileReversions(t *testing.T) {
 	}
 
 	// Test case 7: cesium_ion with different asset_id should not be changed
-	doc7 := bson.M{
+	doc6 := bson.M{
 		"_id": primitive.NewObjectID(),
 		"items": bson.A{
 			bson.M{
@@ -171,7 +152,7 @@ func TestRevertTileAndTerrainProviders_TileReversions(t *testing.T) {
 	}
 
 	// Insert test documents
-	_, err := db.Collection("property").InsertMany(ctx, []any{doc1, doc2, doc3, doc4, doc5, doc6, doc7})
+	_, err := db.Collection("property").InsertMany(ctx, []any{doc1, doc2, doc3, doc4, doc5, doc6})
 	require.NoError(t, err)
 
 	// Run revert migration
@@ -214,23 +195,23 @@ func TestRevertTileAndTerrainProviders_TileReversions(t *testing.T) {
 	assert.Equal(t, "tile_type", fields4[0].(bson.M)["field"])
 	assert.Equal(t, "black_marble", fields4[0].(bson.M)["value"])
 
-	// Verify doc5: carto_light → stamen_toner
+	// Verify doc5: open_street_map → esri_world_topo
 	var updatedDoc5 bson.M
 	err = db.Collection("property").FindOne(ctx, bson.M{"_id": doc5["_id"]}).Decode(&updatedDoc5)
 	require.NoError(t, err)
 	value5 := updatedDoc5["items"].(primitive.A)[0].(bson.M)["groups"].(primitive.A)[0].(bson.M)["fields"].(primitive.A)[0].(bson.M)["value"]
-	assert.Equal(t, "stamen_toner", value5)
+	assert.Equal(t, "esri_world_topo", value5)
 
-	// Verify doc6: open_street_map → esri_world_topo
+	// Verify doc6: cesium_ion with asset_id 999 unchanged
 	var updatedDoc6 bson.M
-	err = db.Collection("property").FindOne(ctx, bson.M{"_id": doc6["_id"]}).Decode(&updatedDoc6)
+	err = db.Collection("property").FindOne(ctx, bson.M{"_id": doc5["_id"]}).Decode(&updatedDoc6)
 	require.NoError(t, err)
 	value6 := updatedDoc6["items"].(primitive.A)[0].(bson.M)["groups"].(primitive.A)[0].(bson.M)["fields"].(primitive.A)[0].(bson.M)["value"]
 	assert.Equal(t, "esri_world_topo", value6)
 
-	// Verify doc7: cesium_ion with asset_id 999 unchanged
+	
 	var updatedDoc7 bson.M
-	err = db.Collection("property").FindOne(ctx, bson.M{"_id": doc7["_id"]}).Decode(&updatedDoc7)
+	err = db.Collection("property").FindOne(ctx, bson.M{"_id": doc6["_id"]}).Decode(&updatedDoc7)
 	require.NoError(t, err)
 	fields7 := updatedDoc7["items"].(primitive.A)[0].(bson.M)["groups"].(primitive.A)[0].(bson.M)["fields"].(primitive.A)
 	assert.Len(t, fields7, 2)
@@ -418,7 +399,7 @@ func TestRevertTileAndTerrainProviders_MultipleTilesInDocument(t *testing.T) {
 						"fields": bson.A{
 							bson.M{
 								"field": "tile_type",
-								"value": "carto_light",
+								"value": "open_street_map",
 							},
 						},
 					},
@@ -458,9 +439,9 @@ func TestRevertTileAndTerrainProviders_MultipleTilesInDocument(t *testing.T) {
 	assert.Len(t, fields1, 1)
 	assert.Equal(t, "default", fields1[0].(bson.M)["value"])
 
-	// Check second tile (carto_light → stamen_toner)
+	// Check second tile (open_street_map → esri_world_topo)
 	fields2 := items[0].(bson.M)["groups"].(primitive.A)[1].(bson.M)["fields"].(primitive.A)
-	assert.Equal(t, "stamen_toner", fields2[0].(bson.M)["value"])
+	assert.Equal(t, "esri_world_topo", fields2[0].(bson.M)["value"])
 
 	// Check terrain (reearth_terrain → arcgis)
 	fields3 := items[1].(bson.M)["groups"].(primitive.A)[0].(bson.M)["fields"].(primitive.A)

--- a/server/internal/infrastructure/mongo/migration/260525000715_update_tile_and_terrain_providers.go
+++ b/server/internal/infrastructure/mongo/migration/260525000715_update_tile_and_terrain_providers.go
@@ -16,7 +16,7 @@ import (
 // - "default_label" → "cesium_ion" with cesium_ion_asset_id: 3
 // - "default_road" → "cesium_ion" with cesium_ion_asset_id: 4
 // - "black_marble" → "cesium_ion" with cesium_ion_asset_id: 3812
-// - "stamen_toner" → "carto_light"
+// - "stamen_toner" → "open_street_map"
 // - "esri_world_topo" → "open_street_map"
 // Terrain migration rules:
 // - "arcgis" → "reearth_terrain"
@@ -44,8 +44,8 @@ func UpdateTileAndTerrainProviders(ctx context.Context, c DBClient) error {
 		return fmt.Errorf("failed to migrate tile 'black_marble': %w", err)
 	}
 
-	// Migration 5: stamen_toner → carto_light (simple rename)
-	if err := migrateTileSimpleRename(ctx, col, "stamen_toner", "carto_light"); err != nil {
+	// Migration 5: stamen_toner → open_street_map (simple rename)
+	if err := migrateTileSimpleRename(ctx, col, "stamen_toner", "open_street_map"); err != nil {
 		return fmt.Errorf("failed to migrate tile 'stamen_toner': %w", err)
 	}
 

--- a/server/internal/infrastructure/mongo/migration/260525000715_update_tile_and_terrain_providers_test.go
+++ b/server/internal/infrastructure/mongo/migration/260525000715_update_tile_and_terrain_providers_test.go
@@ -93,7 +93,7 @@ func TestUpdateTileAndTerrainProviders_TileMigrations(t *testing.T) {
 		},
 	}
 
-	// Test case 5: stamen_toner → carto_light
+	// Test case 5: stamen_toner → open_street_map
 	doc5 := bson.M{
 		"_id": primitive.NewObjectID(),
 		"items": bson.A{
@@ -194,12 +194,12 @@ func TestUpdateTileAndTerrainProviders_TileMigrations(t *testing.T) {
 	assert.Equal(t, "cesium_ion_asset_id", fields4[1].(bson.M)["field"])
 	assert.Equal(t, float64(3812), fields4[1].(bson.M)["value"])
 
-	// Verify doc5: stamen_toner → carto_light
+	// Verify doc5: stamen_toner → open_street_map
 	var updatedDoc5 bson.M
 	err = db.Collection("property").FindOne(ctx, bson.M{"_id": doc5["_id"]}).Decode(&updatedDoc5)
 	require.NoError(t, err)
 	value5 := updatedDoc5["items"].(primitive.A)[0].(bson.M)["groups"].(primitive.A)[0].(bson.M)["fields"].(primitive.A)[0].(bson.M)["value"]
-	assert.Equal(t, "carto_light", value5)
+	assert.Equal(t, "open_street_map", value5)
 
 	// Verify doc6: esri_world_topo → open_street_map
 	var updatedDoc6 bson.M
@@ -393,9 +393,9 @@ func TestUpdateTileAndTerrainProviders_MultipleTilesInDocument(t *testing.T) {
 	assert.Equal(t, "cesium_ion", fields1[0].(bson.M)["value"])
 	assert.Equal(t, "cesium_ion_asset_id", fields1[1].(bson.M)["field"])
 
-	// Check second tile (stamen_toner → carto_light)
+	// Check second tile (stamen_toner → open_street_map)
 	fields2 := items[0].(bson.M)["groups"].(primitive.A)[1].(bson.M)["fields"].(primitive.A)
-	assert.Equal(t, "carto_light", fields2[0].(bson.M)["value"])
+	assert.Equal(t, "open_street_map", fields2[0].(bson.M)["value"])
 
 	// Check terrain (arcgis → reearth_terrain)
 	fields3 := items[1].(bson.M)["groups"].(primitive.A)[0].(bson.M)["fields"].(primitive.A)

--- a/server/internal/infrastructure/mongo/migration/migrations.go
+++ b/server/internal/infrastructure/mongo/migration/migrations.go
@@ -10,15 +10,15 @@ import "github.com/reearth/reearthx/usecasex/migration"
 // If the migration takes too long, the deployment may fail in a serverless environment.
 // Set the batch size to as large a value as possible without using up the RAM of the deployment destination.
 var migrations = migration.Migrations[DBClient]{
-  201217132559: AddSceneWidgetId,
-  201217193948: AddSceneDefaultTile,
-  210310145844: RemovePreviewToken,
-  210730175108: AddSceneAlignSystem,
-  220214180713: SplitSchemaOfProperties,
-  220309174648: AddSceneFieldToPropertySchema,
-  221028204300: MoveTerrainProperties,
-  250602123621: AddDefaultDataAttributionWidget,
-  250821145423: ChangeEsriAndStamenToDefault,
-  251201173239: GcschangeEsriToDefault,
-  260525000715: UpdateTileAndTerrainProviders,
+	201217132559: AddSceneWidgetId,
+	201217193948: AddSceneDefaultTile,
+	210310145844: RemovePreviewToken,
+	210730175108: AddSceneAlignSystem,
+	220214180713: SplitSchemaOfProperties,
+	220309174648: AddSceneFieldToPropertySchema,
+	221028204300: MoveTerrainProperties,
+	250602123621: AddDefaultDataAttributionWidget,
+	250821145423: ChangeEsriAndStamenToDefault,
+	251201173239: GcschangeEsriToDefault,
+	260525000715: UpdateTileAndTerrainProviders,
 }


### PR DESCRIPTION
## Summary

Changes the `stamen_toner` migration target from `carto_light` to `open_street_map`.

**Forward migration:** `stamen_toner` → `open_street_map`

**Revert migration:** removed the `carto_light` → `stamen_toner` reversion. The existing `open_street_map` → `esri_world_topo` revert is unchanged. `stamen_toner` tiles are not explicitly reverted on rollback — they remain as `open_street_map`, which is correct since Stamen shut down in 2023.

## Test plan

- [x] All 12 migration and revert tests pass
- [x] Build passes