### PR TITLE
fix(server): add migration to fix arcgis terrain rename that was skipped

### DIFF
--- a/server/internal/infrastructure/mongo/migration/260528082406_fix_arcgis_terrain_migration.go
+++ b/server/internal/infrastructure/mongo/migration/260528082406_fix_arcgis_terrain_migration.go
@@ -1,0 +1,86 @@
+package migration
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// FixArcgisTerrain re-runs the arcgis → reearth_terrain rename that was skipped by
+// migration 260525000715 due to a wrong document path.
+//
+// Terrain is a plain group item, so terrainType lives at items[].fields[], not
+// items[].groups[].fields[] (which is the grouplist path used by tiles). The
+// original migration queried the grouplist path and matched zero documents.
+func FixArcgisTerrain(ctx context.Context, c DBClient) error {
+	col := c.WithCollection("property").Client()
+
+	if err := fixTerrainSimpleRename(ctx, col, "arcgis", "reearth_terrain"); err != nil {
+		return fmt.Errorf("failed to fix terrain 'arcgis': %w", err)
+	}
+
+	fmt.Println("[migration] FixArcgisTerrain completed successfully")
+	return nil
+}
+
+func fixTerrainSimpleRename(ctx context.Context, col *mongo.Collection, oldValue, newValue string) error {
+	filter := bson.M{
+		"items.fields.field": "terrainType",
+		"items.fields.value": oldValue,
+	}
+
+	countCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	cursor, err := col.Find(countCtx, filter, &options.FindOptions{Projection: bson.M{"id": 1}})
+	if err != nil {
+		return fmt.Errorf("find failed for terrainType '%s': %w", oldValue, err)
+	}
+	var matchedDocs []struct {
+		ID string `bson:"id"`
+	}
+	if err := cursor.All(countCtx, &matchedDocs); err != nil {
+		return fmt.Errorf("cursor failed for terrainType '%s': %w", oldValue, err)
+	}
+	n := int64(len(matchedDocs))
+
+	fmt.Printf("[migration] target documents for terrainType '%s': %d\n", oldValue, n)
+	if n == 0 {
+		fmt.Printf("[migration] nothing to do for terrainType '%s'\n", oldValue)
+		return nil
+	}
+	for _, doc := range matchedDocs {
+		fmt.Printf("[migration]   property id=%s will be migrated: terrainType %s -> %s\n", doc.ID, oldValue, newValue)
+	}
+
+	update := bson.M{
+		"$set": bson.M{
+			"items.$[i].fields.$[f].value": newValue,
+		},
+	}
+	arrayFilters := options.ArrayFilters{
+		Filters: []any{
+			bson.M{"i.fields": bson.M{"$type": "array"}},
+			bson.M{
+				"f.field": "terrainType",
+				"f.value": oldValue,
+			},
+		},
+	}
+	opts := options.Update().SetArrayFilters(arrayFilters)
+
+	updateCtx, cancel2 := context.WithTimeout(ctx, 30*time.Minute)
+	defer cancel2()
+
+	res, err := col.UpdateMany(updateCtx, filter, update, opts)
+	if err != nil {
+		return fmt.Errorf("update failed for terrainType '%s': %w", oldValue, err)
+	}
+
+	fmt.Printf("[migration] terrainType '%s' → '%s': matched: %d, modified: %d\n", oldValue, newValue, res.MatchedCount, res.ModifiedCount)
+	return nil
+}

--- a/server/internal/infrastructure/mongo/migration/260528082406_fix_arcgis_terrain_migration_test.go
+++ b/server/internal/infrastructure/mongo/migration/260528082406_fix_arcgis_terrain_migration_test.go
@@ -1,0 +1,107 @@
+package migration
+
+import (
+	"context"
+	"testing"
+
+	"github.com/reearth/reearthx/mongox"
+	"github.com/reearth/reearthx/mongox/mongotest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+func TestFixArcgisTerrain(t *testing.T) {
+	ctx := context.Background()
+	db := mongotest.Connect(t)(t)
+	c := mongox.NewClientWithDatabase(db)
+
+	// Realistic property document: a tiles grouplist item followed by a terrain group item,
+	// matching the structure seen in production (confirmed via mongodoc.PropertyDocument).
+	// Terrain (group) stores fields at items[].fields[], not items[].groups[].fields[].
+	docArcgis := bson.M{
+		"_id": primitive.NewObjectID(),
+		"id":  "test-arcgis-prop-001",
+		"items": bson.A{
+			bson.M{
+				"type":        "grouplist",
+				"schemagroup": "tiles",
+				"groups": bson.A{
+					bson.M{
+						"type":   "group",
+						"fields": bson.A{bson.M{"field": "tile_type", "type": "STRING", "value": "open_street_map"}},
+					},
+				},
+			},
+			bson.M{
+				"type":        "group",
+				"schemagroup": "terrain",
+				"fields": bson.A{
+					bson.M{"field": "terrain", "type": "BOOL", "value": true},
+					bson.M{"field": "terrainType", "type": "STRING", "value": "arcgis"},
+				},
+			},
+		},
+	}
+
+	// A doc with cesium terrain — must not be touched.
+	docCesium := bson.M{
+		"_id": primitive.NewObjectID(),
+		"id":  "test-cesium-prop-001",
+		"items": bson.A{
+			bson.M{
+				"type":        "group",
+				"schemagroup": "terrain",
+				"fields": bson.A{
+					bson.M{"field": "terrain", "type": "BOOL", "value": true},
+					bson.M{"field": "terrainType", "type": "STRING", "value": "cesium"},
+				},
+			},
+		},
+	}
+
+	// A doc with no terrain at all — must not be touched.
+	docNoTerrain := bson.M{
+		"_id": primitive.NewObjectID(),
+		"id":  "test-no-terrain-prop-001",
+		"items": bson.A{
+			bson.M{
+				"type":        "grouplist",
+				"schemagroup": "tiles",
+				"groups": bson.A{
+					bson.M{
+						"type":   "group",
+						"fields": bson.A{bson.M{"field": "tile_type", "type": "STRING", "value": "open_street_map"}},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := db.Collection("property").InsertMany(ctx, []any{docArcgis, docCesium, docNoTerrain})
+	require.NoError(t, err)
+
+	err = FixArcgisTerrain(ctx, c)
+	require.NoError(t, err)
+
+	// arcgis → reearth_terrain, terrain: true preserved
+	var result1 bson.M
+	require.NoError(t, db.Collection("property").FindOne(ctx, bson.M{"_id": docArcgis["_id"]}).Decode(&result1))
+	terrainItem := result1["items"].(primitive.A)[1].(bson.M)
+	fields1 := terrainItem["fields"].(primitive.A)
+	assert.Equal(t, true, fields1[0].(bson.M)["value"], "terrain: true should be preserved")
+	assert.Equal(t, "reearth_terrain", fields1[1].(bson.M)["value"], "arcgis should become reearth_terrain")
+
+	// cesium unchanged
+	var result2 bson.M
+	require.NoError(t, db.Collection("property").FindOne(ctx, bson.M{"_id": docCesium["_id"]}).Decode(&result2))
+	fields2 := result2["items"].(primitive.A)[0].(bson.M)["fields"].(primitive.A)
+	assert.Equal(t, "cesium", fields2[1].(bson.M)["value"], "cesium terrain should be unchanged")
+
+	// tile-only doc unchanged
+	var result3 bson.M
+	require.NoError(t, db.Collection("property").FindOne(ctx, bson.M{"_id": docNoTerrain["_id"]}).Decode(&result3))
+	tileGroups := result3["items"].(primitive.A)[0].(bson.M)["groups"].(primitive.A)
+	assert.Equal(t, "open_street_map", tileGroups[0].(bson.M)["fields"].(primitive.A)[0].(bson.M)["value"])
+}

--- a/server/internal/infrastructure/mongo/migration/migrations.go
+++ b/server/internal/infrastructure/mongo/migration/migrations.go
@@ -21,4 +21,5 @@ var migrations = migration.Migrations[DBClient]{
 	250821145423: ChangeEsriAndStamenToDefault,
 	251201173239: GcschangeEsriToDefault,
 	260525000715: UpdateTileAndTerrainProviders,
+	260528082406: FixArcgisTerrain,
 }


### PR DESCRIPTION
## Summary

- Migration `260525000715` used the grouplist document path (`items.groups.fields`) to query `terrainType`, but terrain is a plain group item whose fields live at `items.fields` — one level shallower. The filter matched zero documents, so every scene using ArcGIS terrain was silently skipped.
- Adds new migration `260528082406` (`FixArcgisTerrain`) to re-run the `arcgis → reearth_terrain` rename with the correct path.
- The old migration is left untouched since it has already been recorded as complete in deployed environments.

## Test plan

- [x] `TestFixArcgisTerrain` passes against a real MongoDB instance (`REEARTH_DB=<uri> go test ./server/internal/infrastructure/mongo/migration/... -run TestFixArcgisTerrain`)
- [x] Verified locally: inserted a test document with the real production structure (`items[group].fields[terrainType=arcgis]`), confirmed old path matched 0 docs and new path matched 1, migration updated value to `reearth_terrain`