### PR TITLE
fix(server): remove migrations that might after last migration

### DIFF
--- a/server/internal/infrastructure/mongo/migration/migrations.go
+++ b/server/internal/infrastructure/mongo/migration/migrations.go
@@ -18,8 +18,6 @@ var migrations = migration.Migrations[DBClient]{
 	220309174648: AddSceneFieldToPropertySchema,
 	221028204300: MoveTerrainProperties,
 	250602123621: AddDefaultDataAttributionWidget,
-	250821145423: ChangeEsriAndStamenToDefault,
-	251201173239: GcschangeEsriToDefault,
 	260525000715: UpdateTileAndTerrainProviders,
 	260528082406: FixArcgisTerrain,
 }


### PR DESCRIPTION
These two migrations 
```
	250821145423: ChangeEsriAndStamenToDefault,
	251201173239: GcschangeEsriToDefault,
```

will affect the last two results
```
260525000715: UpdateTileAndTerrainProviders,
260528082406: FixArcgisTerrain,	
```
