### PR TITLE
ci: set renovate rebaseWhen to conflicted

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,5 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>reearth/renovate-config"
-  ]
+  ],
+  "rebaseWhen": "conflicted"
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,5 +3,19 @@
   "extends": [
     "github>reearth/renovate-config"
   ],
-  "rebaseWhen": "conflicted"
+  "rebaseWhen": "conflicted",
+  "packageRules": [
+    {
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "Go dependencies",
+      "groupSlug": "gomod"
+    },
+    {
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "{{depName}} (major)",
+      "groupSlug": "{{depNameSanitized}}-major"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Sets `rebaseWhen: "conflicted"` in `.github/renovate.json`
- Prevents Renovate from rebasing all open PRs whenever a commit lands on main
- PRs will only be rebased automatically when they have an actual merge conflict

## Test plan
- [ ] Merge something to main and verify Renovate PRs are not automatically triggered