### PR TITLE
chore: pin workflow actions to commit SHAs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -72,7 +72,7 @@ jobs:
         with:
           egress-policy: audit
       - name: Slack Notification
-        uses: Gamesight/slack-workflow-status@master
+        uses: Gamesight/slack-workflow-status@2e709ce51fd47f02b7221db8547e6e6f49f81f1d # master
         if: always()
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
       - id: changelog
         name: Generate CHANGELOG
-        uses: reearth/changelog-action@main
+        uses: reearth/changelog-action@86cb9d7a3727f3cb6afe36a1536fad61e9775287 # main
         with:
           version: ${{ github.event.inputs.version }}
           repo: ${{ github.repository }}


### PR DESCRIPTION
Pin unpinned GitHub Actions to specific commit SHAs to prevent potential security vulnerabilities from branch compromise.

Changes:
- Pin Gamesight/slack-workflow-status from @master to commit SHA
- Pin reearth/changelog-action from @main to commit SHA

Resolves security scan finding: actions-pinned error

# Overview

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
