### PR TITLE
chore(server): bump Go to 1.26.5

### DIFF
--- a/go.work
+++ b/go.work
@@ -1,3 +1,3 @@
-go 1.25.0
+go 1.26.5
 
 use ./server

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine AS build
+FROM golang:1.26.5-alpine AS build
 ARG TAG=release
 ARG VERSION
 

--- a/server/go.mod
+++ b/server/go.mod
@@ -173,4 +173,4 @@ require (
 	moul.io/http2curl v1.0.1-0.20190925090545-5cd742060b0e // indirect
 )
 
-go 1.25.0
+go 1.26.5


### PR DESCRIPTION
## Summary

Bumps the Go version used by the server from 1.25.0 to 1.26.5.

- `go.work` / `server/go.mod`: `go 1.25.0` → `go 1.26.5`
- `server/Dockerfile`: `golang:1.25-alpine` → `golang:1.26.5-alpine` (exact pinned patch tag, matching the repo's approach of pinning versions rather than tracking floating tags)

## Why the Dockerfile change is required

Bumping only `go.mod` without touching the Dockerfile breaks the image build: the Alpine build image has `GOTOOLCHAIN=local`, so it refuses to auto-download a newer toolchain and fails hard:

```
go: go.mod requires go >= 1.26.5 (running go 1.25.12; GOTOOLCHAIN=local)
```

This wouldn't have been caught by regular PR CI since `build_server`/`ci_docker_build_push` don't run on every PR — only confirmed by building the image locally.

## reearthx compatibility

`github.com/reearth/reearthx` declares `go 1.21` in its own `go.mod` (no `replace`/`toolchain` override), so it's fully forward-compatible with 1.26.5. It already compiles/tests/races clean as part of the full server build below.

## Test plan

- [x] `go build ./...`, `go build -race ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — all packages pass
- [x] `gofmt -l .` — no diff
- [x] `golangci-lint run` (matches CI config) — 0 issues
- [x] `go mod verify` — all modules verified
- [x] Confirmed `go mod tidy` produces the same (pre-existing, unrelated) diff at 1.25.0 — not caused by this bump
- [x] `docker build` with `golang:1.26.5-alpine` — succeeds; ran the resulting binary and confirmed it boots and loads config