### PR TITLE
chore: bump local/CI mongo image to 7-jammy

### DIFF
--- a/.github/workflows/ci_server.yml
+++ b/.github/workflows/ci_server.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       mongo:
-        image: mongo:5-focal
+        image: mongo:7-jammy
         ports:
           - 27017:27017
     steps:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     volumes:
       - ./data:/reearth/data
   reearth-mongo:
-    image: mongo:5-focal
+    image: mongo:7-jammy
     ports:
       - 27017:27017
     volumes:


### PR DESCRIPTION
## Summary

Bumps the MongoDB image used in `docker-compose.yml` (local dev) and `.github/workflows/ci_server.yml` (CI tests) from `mongo:5-focal` to `mongo:7-jammy`.

## Why

Local/CI were pinned to Mongo 5, two majors behind what production actually runs. Traced through the `infrastructure` repo:

- `terraform/reearth/prod/mongodbatlas_advanced_cluster.tf`: cluster `reearth-production`, `mongo_db_major_version = "7.0"`
- `terraform/reearth/prod/mongodbatlas_custom_db_role.tf`: role `reearth` grants access to database `"reearth"` specifically (distinct from `reearth-account(s)`/`reearth-visualizer`, which belong to other apps sharing the same Atlas project)
- `server/internal/app/repo.go:27` in this repo hardcodes `const databaseName = "reearth"` — matching the database name above
- `terraform/reearth/prod/google_secret_manager_secret.tf` has a secret commented `# For Re:Earth Classic.` with `secret_id = "reearth-db"`, the same ID wired into the `REEARTH_DB` env var in `modules/reearth_classic_api/google_cloud_run_v2_service.tf`

Note: Mongo dropped Ubuntu Focal images starting at 7.x — there's no `mongo:7-focal` tag, so this uses `mongo:7-jammy` instead (same floating major+distro tag style as the existing `5-focal` pin).

**⚠️ Please double check with SRE/infra that `7.0` is still accurate for the current production cluster before merging** — the Terraform config is the best signal available from this repo, but the actual Atlas cluster could have moved since, and I don't have direct access to confirm against the live cluster.

## Test plan

- [x] Pulled and ran `mongo:7-jammy` locally
- [x] `go test ./... -race` against it — all packages pass, including `internal/infrastructure/mongo` and `internal/infrastructure/mongo/migration`