### PR TITLE
chore(web): allow pull request target

### DIFF
--- a/.github/workflows/reviewer_lottery.yml
+++ b/.github/workflows/reviewer_lottery.yml
@@ -1,6 +1,6 @@
 name: Reviewer lottery
 on:
-  pull_request_target:
+  pull_request_target: # git-cascade:allow 
     paths:
         - web/**
     types: [opened, ready_for_review, reopened]


### PR DESCRIPTION
# Overview

Allow it since it's safe:
1. It only checks out the base repository code (line 19), NOT the PR code
2. It doesn't use any untrusted code from the PR
3. It only runs a pinned, trusted action that assigns reviewers
4. Permissions are limited (contents: read, pull-requests: write)

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
